### PR TITLE
Treat warning as deprecations:

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,11 @@ DeprecationToolkit::Configuration.allowed_deprecations = [/Hello World/]
 ActiveSupport::Deprecation.warn('Hello World')
 ```
 
+🔨 `#DeprecationToolkit::Configuration#warnings_treated_as_deprecation`
+
+```
+Most gems doesn't use ActiveSupport::Deprecation to deprecate their code but instead just uses `Kernel#warn` to output
+a message in the console.
+The DeprecationToolkit gem allows you to configure which warnings should be treated as deprecations in order for you
+to keep track of them as if they were regular deprecations.
+```

--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "deprecation_toolkit/minitest_hook"
+require "deprecation_toolkit/warning"
 
 module DeprecationToolkit
   autoload :DeprecationSubscriber,     "deprecation_toolkit/deprecation_subscriber"

--- a/lib/deprecation_toolkit/configuration.rb
+++ b/lib/deprecation_toolkit/configuration.rb
@@ -10,5 +10,6 @@ module DeprecationToolkit
     config_accessor(:allowed_deprecations) { [] }
     config_accessor(:deprecation_path) { "test/deprecations" }
     config_accessor(:attach_to) { [:rails] }
+    config_accessor(:warnings_treated_as_deprecation) { [] }
   end
 end

--- a/lib/deprecation_toolkit/warning.rb
+++ b/lib/deprecation_toolkit/warning.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DeprecationToolkit
+  module Warning
+    def warn(str)
+      if DeprecationToolkit::Configuration.warnings_treated_as_deprecation.any? { |warning| warning =~ str }
+        ActiveSupport::Deprecation.warn(str)
+      else
+        super
+      end
+    end
+  end
+end
+
+Warning.singleton_class.prepend(DeprecationToolkit::Warning)
+
+# https://bugs.ruby-lang.org/issues/12944
+if Gem::Version.new(ENV['RUBY_VERSION']) <= Gem::Version.new('2.5')
+  module Kernel
+    def warn(str)
+      Warning.warn(str)
+    end
+  end
+end

--- a/test/deprecation_toolkit/warning_test.rb
+++ b/test/deprecation_toolkit/warning_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module DeprecationToolkit
+  class WarningTest < ActiveSupport::TestCase
+    setup do
+      @previous_warnings_treated_as_deprecation = Configuration.warnings_treated_as_deprecation
+    end
+
+    teardown do
+      Configuration.warnings_treated_as_deprecation = @previous_warnings_treated_as_deprecation
+    end
+
+    test 'treats warnings as deprecations' do
+      Configuration.warnings_treated_as_deprecation = [/#example is deprecated/]
+
+      assert_raises Behaviors::DeprecationIntroduced do
+        warn '#example is deprecated'
+
+        trigger_deprecation_toolkit_behavior
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Keep track of deprecations that comes from gem wich uses `Kernel#warn` to deprecated their code

Fixes #3