### PR TITLE
Add DeprecationToolkit.initialize method

### DIFF
--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -26,6 +26,15 @@ module DeprecationToolkit
       DeprecationSubscriber.attach_to gem_name
     end
   end
+
+  def self.initialize
+    unless defined?(@initialized)
+      add_notify_behavior
+      attach_subscriber
+
+      @initialized = true
+    end
+  end
 end
 
 require "deprecation_toolkit/minitest_hook"

--- a/lib/minitest/deprecation_toolkit_plugin.rb
+++ b/lib/minitest/deprecation_toolkit_plugin.rb
@@ -14,7 +14,6 @@ module Minitest
       DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Record
     end
 
-    DeprecationToolkit.add_notify_behavior
-    DeprecationToolkit.attach_subscriber
+    DeprecationToolkit.initialize
   end
 end

--- a/test/deprecation_toolkit/initialization_test.rb
+++ b/test/deprecation_toolkit/initialization_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module DeprecationToolkit
+  class InitializationTest < ActiveSupport::TestCase
+    test "calling .initialize again will not attach another subscriber" do
+      assert_equal 1, DeprecationToolkit::DeprecationSubscriber.subscribers.count
+
+      DeprecationToolkit.initialize
+
+      assert_equal 1, DeprecationToolkit::DeprecationSubscriber.subscribers.count
+    end
+  end
+end


### PR DESCRIPTION
This method is, by default, called by the Minitest plugin init hook:
https://github.com/Shopify/deprecation_toolkit/blob/802a0b8dd525bc0e9c4142127cba51dc0ffadd76/lib/minitest/deprecation_toolkit_plugin.rb#L12-L18

However, it can be called earlier if you want to catch deprecations that are emitted before Minitest initializes its plugins (which is `at_exit`).

Addresses https://github.com/Shopify/deprecation_toolkit/issues/21