### PR TITLE
Don't re-attach the subscriber if already attached:

### DIFF
--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -23,6 +23,8 @@ module DeprecationToolkit
 
   def self.attach_subscriber
     Configuration.attach_to.each do |gem_name|
+      next if DeprecationSubscriber.already_attached?
+
       DeprecationSubscriber.attach_to gem_name
     end
   end

--- a/lib/deprecation_toolkit/deprecation_subscriber.rb
+++ b/lib/deprecation_toolkit/deprecation_subscriber.rb
@@ -4,6 +4,10 @@ require "active_support/subscriber"
 
 module DeprecationToolkit
   class DeprecationSubscriber < ActiveSupport::Subscriber
+    def self.already_attached?
+      notifier != nil
+    end
+
     def deprecation(event)
       message = event.payload[:message]
 

--- a/test/minitest/deprecation_toolkit_plugin_test.rb
+++ b/test/minitest/deprecation_toolkit_plugin_test.rb
@@ -5,12 +5,6 @@ require "optparse"
 
 module Minitest
   class DeprecationToolkitPluginTest < ActiveSupport::TestCase
-    if ActiveSupport.gem_version.to_s < "5.0"
-      parallelize_me!
-    else
-      include ActiveSupport::Testing::Isolation
-    end
-
     test ".plugin_deprecation_toolkit_options when running test with the `-r` flag" do
       option_parser = OptionParser.new
       options = {}


### PR DESCRIPTION
- If the DeprecationSubscriber gets attached to the `rails` namespace
  before the minitest plugin initialization kicks in, the gem would
  attach the subscriber twice which would send 2 notifications per
  deprecation.

  Removed the testing isolation from the test as it was needed because
  of this issue.