### PR TITLE
Return earlier if Subscriber is already attached:

### DIFF
--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -22,9 +22,9 @@ module DeprecationToolkit
   end
 
   def self.attach_subscriber
-    Configuration.attach_to.each do |gem_name|
-      next if DeprecationSubscriber.already_attached?
+    return if DeprecationSubscriber.already_attached?
 
+    Configuration.attach_to.each do |gem_name|
       DeprecationSubscriber.attach_to gem_name
     end
   end


### PR DESCRIPTION
- If an app decide for some reason to attach namespace on the
  subscriber before the minitest hook is triggered, we don't want to
  reattach the same namespace on the subscriber again. Otherwise each
  deprecations would trigger two warnings.

  In #26, I made this change but this causes issue if a gem want to
  attach multiple namespace to the subscriber.
  Only the first namespace will be attached.