### PR TITLE
Allow Procs inside the `Configuration.allowed_deprecations` array:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## master (unreleased)
 ### Bug fixes
 
+### New Features
+* [#28](https://github.com/Shopify/deprecation_toolkit/pull/28): `Configuration.allowed_deprecations now accepts Procs.
+  This is useful if you need to whitelist deprecations based on the caller.
+
 ## 1.0.3 (2018-10-25)
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ DeprecationToolkit::Configuration.behavior = StatsdBehavior
 
 ### 🔨 `#DeprecationToolkit::Configuration#allowed_deprecations`
 
-You can ignore some deprecations using `allowed_deprecations`. `allowed_deprecations` accepts an array of Regexp.
+You can ignore some deprecations using `allowed_deprecations`. `allowed_deprecations` accepts an array of Regexp and Procs.
 
 Whenever a deprecation matches one of the regex, it is ignored.
 
@@ -81,6 +81,19 @@ Whenever a deprecation matches one of the regex, it is ignored.
 DeprecationToolkit::Configuration.allowed_deprecations = [/Hello World/]
 
 ActiveSupport::Deprecation.warn('Hello World') # ignored by Deprecation Toolkit
+```
+
+When passing procs, each proc will get passed the deprecation message and the callstack.
+This is useful if you want to whitelist deprecations based on the caller.
+
+```ruby
+DeprecationToolkit::Configuration.allowed_deprecations = [
+  ->(message, stack) { message ~= 'Foo' && stack.first.label == 'method_triggering_deprecation' }
+]
+
+def method_triggering_deprecation
+  ActiveSupport::Deprecation.warn('Foo') # Ignored by the the DeprecationToolkit
+end
 ```
 
 ### 🔨 `#DeprecationToolkit::Configuration#warnings_treated_as_deprecation`


### PR DESCRIPTION
- It's sometimes useful to allow some deprecations based on where they
  get called from.

  Imagine this kind of code:
  ```ruby
    def foo
      1000.times do
        deprecation_call
      end
    end

    def bar
      deprecation_call
    end

    private

    def deprecation_call
      ActiveSupport::Deprecation.warn('Something')
    end
  ```

  Calling `foo`, will trigger a thousand deprecations that you'll to
  record. You currently can whitelist the `Something` deprecation,
  but if you do that will also ignore the deprecation that gets
  triggered when calling `bar`.

  If you want to fine grain, which deprecations should be allowed
  based on the caller, then this PR allows you that.

  The `Configuration.allowed_deprecations` now accepts procs. Procs
  will be passed the deprecation message as well as the stacktrace.
  Your proc needs to return a truthy value if the deprecation is
  allowed.