### PR TITLE
Fix issue where deprecation error raised could be incorrect:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master (unreleased)
 ### Bug fixes
 
+* [#29](https://github.com/Shopify/deprecation_toolkit/pull/29): Fix issue where the error class triggered was incorrect in some circumstances. (@Edouard-chin)
+
 ## 1.1.0 (2018-11-13)
 ### New Features
 * [#28](https://github.com/Shopify/deprecation_toolkit/pull/28): `Configuration.allowed_deprecations now accepts Procs.

--- a/lib/deprecation_toolkit/behaviors/raise.rb
+++ b/lib/deprecation_toolkit/behaviors/raise.rb
@@ -4,7 +4,7 @@ module DeprecationToolkit
   module Behaviors
     class Raise
       def self.trigger(_test, current_deprecations, recorded_deprecations)
-        error_class = if current_deprecations > recorded_deprecations
+        error_class = if current_deprecations.size > recorded_deprecations.size
           DeprecationIntroduced
         else
           DeprecationRemoved

--- a/lib/deprecation_toolkit/collector.rb
+++ b/lib/deprecation_toolkit/collector.rb
@@ -9,6 +9,7 @@ module DeprecationToolkit
 
     class_attribute :deprecations
     self.deprecations = []
+    delegate :size, to: :deprecations
 
     class << self
       def collect(message)

--- a/test/deprecation_toolkit/behaviors/raise_test.rb
+++ b/test/deprecation_toolkit/behaviors/raise_test.rb
@@ -27,6 +27,12 @@ module DeprecationToolkit
         ActiveSupport::Deprecation.warn("Foo")
       end
 
+      test '.trigger raises a DeprecationRemoved when less deprecations than expected are triggerd and mismatches' do
+        @expected_exception = DeprecationRemoved
+
+        ActiveSupport::Deprecation.warn("C")
+      end
+
       test ".trigger does not raise when deprecations are triggered but were already recorded" do
         assert_nothing_raised do
           ActiveSupport::Deprecation.warn("Foo")

--- a/test/deprecations/deprecation_toolkit/behaviors/raise_test.yml
+++ b/test/deprecations/deprecation_toolkit/behaviors/raise_test.yml
@@ -5,3 +5,6 @@ test_.trigger_raises_a_DeprecationRemoved_error_when_deprecations_are_removed:
 test_.trigger_does_not_raise_when_deprecations_are_triggered_but_were_already_recorded:
 - 'DEPRECATION WARNING: Foo'
 - 'DEPRECATION WARNING: Bar'
+test_.trigger_raises_a_DeprecationRemoved_when_less_deprecations_than_expected_are_triggerd_and_mismatches:
+- 'DEPRECATION_WARNING: A'
+- 'DEPRECATION_WARNING: B'


### PR DESCRIPTION
- The error class triggered was, in some circumstances not the right
  on (DeprecationRemoved instead of DeprecationIntroduced and vice
  versa).

  If the triggered deprecations were looking like `['C']` and the
  recorded one like `['A', 'B']` it should have raised a
  DeprecationRemoved error, but it was instead triggering a
  DeprecationIntroduced one.

  That situation was happening because we were comparing the recorded
  deprecations agains the triggered one using the `<=>` operator
  on arrays (Returns as soon as one element mismatch.)

  Fix is to use the `<=>` operator on the Array's size instead.