### PR TITLE
Introduce a new `DeprecationMismatch` error class:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
 ## master (unreleased)
+### New Features
+
+* [#30](https://github.com/Shopify/deprecation_toolkit/pull/30): Introduce a `DeprecationMismatch` error class. (@Edouard-chin)
 ### Bug fixes
 
 * [#29](https://github.com/Shopify/deprecation_toolkit/pull/29): Fix issue where the error class triggered was incorrect in some circumstances. (@Edouard-chin)

--- a/test/deprecation_toolkit/behaviors/raise_test.rb
+++ b/test/deprecation_toolkit/behaviors/raise_test.rb
@@ -33,6 +33,12 @@ module DeprecationToolkit
         ActiveSupport::Deprecation.warn("C")
       end
 
+      test '.trigger raises a DeprecationMismatch when same number of deprecations are triggered with mismatches' do
+        @expected_exception = DeprecationMismatch
+
+        ActiveSupport::Deprecation.warn("A")
+      end
+
       test ".trigger does not raise when deprecations are triggered but were already recorded" do
         assert_nothing_raised do
           ActiveSupport::Deprecation.warn("Foo")
@@ -79,7 +85,7 @@ module DeprecationToolkit
       def trigger_deprecation_toolkit_behavior
         super
         flunk if defined?(@expected_exception)
-      rescue DeprecationIntroduced, DeprecationRemoved => e
+      rescue DeprecationIntroduced, DeprecationRemoved, DeprecationMismatch => e
         assert_equal @expected_exception, e.class
       end
     end

--- a/test/deprecations/deprecation_toolkit/behaviors/raise_test.yml
+++ b/test/deprecations/deprecation_toolkit/behaviors/raise_test.yml
@@ -8,3 +8,5 @@ test_.trigger_does_not_raise_when_deprecations_are_triggered_but_were_already_re
 test_.trigger_raises_a_DeprecationRemoved_when_less_deprecations_than_expected_are_triggerd_and_mismatches:
 - 'DEPRECATION_WARNING: A'
 - 'DEPRECATION_WARNING: B'
+test_.trigger_raises_a_DeprecationMismatch_when_same_number_of_deprecations_are_triggered_with_mismatches:
+- 'DEPRECATION_WARNING: C'


### PR DESCRIPTION
- If the number of triggered deprecations were the same as the number
  of recorded one but they weren't matching the DeprecationToolkit
  would have returned a `DeprecationRemoved` error. This is actually
  misleading as it wasn't the case.

  This PR introduces a `DeprecationMismatch` when this situation
  happens.