### PR TITLE
Add rspec support

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--format documentation
+--color
+--require spec_helper
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ gemfile:
 script:
   - bundle exec rubocop --config .rubocop.yml
   - bundle exec rake test
+  - bundle exec rspec
 notifications:
   email: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
       tzinfo (~> 1.1)
     ast (2.4.0)
     concurrent-ruby (1.1.4)
+    diff-lcs (1.3)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
@@ -24,6 +25,19 @@ GEM
     psych (3.1.0)
     rainbow (3.0.0)
     rake (12.3.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     rubocop (0.67.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -46,6 +60,7 @@ DEPENDENCIES
   deprecation_toolkit!
   minitest (~> 5.0)
   rake
+  rspec (~> 3.0)
   rubocop
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -114,6 +114,27 @@ a message in the console.
 Deprecation Toolkit allows you to configure which warnings should be treated as deprecations in order for you
 to keep track of them as if they were regular deprecations.
 
+
+## RSpec
+
+By default Deprecation Toolkit uses Minitest as its test runner. To use Deprecation Toolkit with RSpec you'll have to configure it.
+
+```ruby
+DeprecationToolkit::Configuration.test_runner = :rspec
+```
+
+Also make sure to require the before/after hooks in your `spec_helper.rb` or `rails_helper.rb`.
+
+```ruby
+require "deprecation_toolkit/rspec"
+```
+
+It's possible to record deprecations while running your specs by adding an ENV['DEPRECATION_BEHAVIOR'] variable to your test run. Run your specs with this ENV set to `"record-deprecations"`, `"record"` (or simply the `"r"` shortcut).
+
+```sh
+DEPRECATION_BEHAVIOR="record" bundle exec rspec path/to/file_spec.rb
+```
+
 ## License
 
 Deprecation Toolkit is licensed under the [MIT license](LICENSE.txt).

--- a/deprecation_toolkit.gemspec
+++ b/deprecation_toolkit.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("bundler", ">= 1.16")
   spec.add_development_dependency("rake", "~> 10.0")
   spec.add_development_dependency("minitest", "~> 5.0")
+  spec.add_development_dependency("rspec", "~> 3.0")
 end

--- a/gemfiles/spec/deprecations/deprecation_toolkit/behaviors/raise.yml
+++ b/gemfiles/spec/deprecations/deprecation_toolkit/behaviors/raise.yml
@@ -1,0 +1,12 @@
+---
+test_deprecation_toolkit/behaviors/raise_.trigger_raises_a_deprecation_removed_error_when_deprecations_are_removed:
+- 'DEPRECATION WARNING: Foo'
+- 'DEPRECATION WARNING: Bar'
+test_deprecation_toolkit/behaviors/raise_.trigger_raises_a_deprecation_removed_when_mismatched_and_less_than_expected:
+- 'DEPRECATION WARNING: A'
+- 'DEPRECATION WARNING: B'
+test_deprecation_toolkit/behaviors/raise_.trigger_raises_a_deprecation_mismatch_when_same_number_of_deprecations_are_triggered_with_mismatches:
+- 'DEPRECATION WARNING: C'
+test_deprecation_toolkit/behaviors/raise_.trigger_does_not_raise_when_deprecations_are_triggered_but_were_already_recorded:
+- 'DEPRECATION WARNING: Foo'
+- 'DEPRECATION WARNING: Bar'

--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -7,6 +7,7 @@ module DeprecationToolkit
   autoload :Configuration,             "deprecation_toolkit/configuration"
   autoload :Collector,                 "deprecation_toolkit/collector"
   autoload :ReadWriteHelper,           "deprecation_toolkit/read_write_helper"
+  autoload :TestTriggerer,             "deprecation_toolkit/test_triggerer"
 
   module Behaviors
     autoload :Disabled,                "deprecation_toolkit/behaviors/disabled"
@@ -33,5 +34,8 @@ module DeprecationToolkit
   end
 end
 
-require "deprecation_toolkit/minitest_hook"
+unless defined?(RSpec)
+  require "deprecation_toolkit/minitest_hook"
+end
+
 require "deprecation_toolkit/warning"

--- a/lib/deprecation_toolkit/behaviors/ci_record_helper.rb
+++ b/lib/deprecation_toolkit/behaviors/ci_record_helper.rb
@@ -14,7 +14,7 @@ module DeprecationToolkit
 
         to_output = {
           filename.to_s => {
-            test.name => current_deprecations.deprecations_without_stacktrace,
+            test_name(test) => current_deprecations.deprecations_without_stacktrace,
           },
         }
 

--- a/lib/deprecation_toolkit/behaviors/raise.rb
+++ b/lib/deprecation_toolkit/behaviors/raise.rb
@@ -21,10 +21,16 @@ module DeprecationToolkit
     class DeprecationIntroduced < DeprecationException
       def initialize(current_deprecations, recorded_deprecations)
         introduced_deprecations = current_deprecations - recorded_deprecations
+        record_message =
+          if DeprecationToolkit::Configuration.test_runner == :rspec
+            "You can record deprecations by adding the `DEPRECATION_BEHAVIOR='record'` ENV when running your specs."
+          else
+            "You can record deprecations by adding the `--record-deprecations` flag when running your tests."
+          end
 
         message = <<~EOM
           You have introduced new deprecations in the codebase. Fix or record them in order to discard this error.
-          You can record deprecations by adding the `--record-deprecations` flag when running your tests.
+          #{record_message}
 
           #{introduced_deprecations.join("\n")}
         EOM
@@ -37,10 +43,17 @@ module DeprecationToolkit
       def initialize(current_deprecations, recorded_deprecations)
         removed_deprecations = recorded_deprecations - current_deprecations
 
+        record_message =
+          if DeprecationToolkit::Configuration.test_runner == :rspec
+            "You can re-record deprecations by setting the `DEPRECATION_BEHAVIOR='record'` ENV when running your specs."
+          else
+            "You can re-record deprecations by adding the `--record-deprecations` flag when running your tests."
+          end
+
         message = <<~EOM
           You have removed deprecations from the codebase. Thanks for being an awesome person.
           The recorded deprecations needs to be updated to reflect your changes.
-          You can re-record deprecations by adding the `--record-deprecations` flag when running your tests.
+          #{record_message}
 
           #{removed_deprecations.join("\n")}
         EOM
@@ -51,11 +64,17 @@ module DeprecationToolkit
 
     class DeprecationMismatch < DeprecationException
       def initialize(current_deprecations, recorded_deprecations)
+        record_message =
+          if DeprecationToolkit::Configuration.test_runner == :rspec
+            "You can re-record deprecations by adding the `DEPRECATION_BEHAVIOR='record'` ENV when running your specs."
+          else
+            "You can re-record deprecations by adding the `--record-deprecations` flag when running your tests."
+          end
         message = <<~EOM
           The recorded deprecations for this test doesn't match the one that got triggered.
           Fix or record the new deprecations to discard this error.
 
-          You can re-record deprecations by adding the `--record-deprecations` flag when running your tests.
+          #{record_message}
 
           ===== Expected
           #{recorded_deprecations.deprecations.join("\n")}

--- a/lib/deprecation_toolkit/behaviors/record.rb
+++ b/lib/deprecation_toolkit/behaviors/record.rb
@@ -8,7 +8,7 @@ module DeprecationToolkit
       def self.trigger(test, collector, _)
         deprecation_file = recorded_deprecations_path(test)
 
-        write(deprecation_file, test.name => collector.deprecations_without_stacktrace)
+        write(deprecation_file, test_name(test) => collector.deprecations_without_stacktrace)
       end
     end
   end

--- a/lib/deprecation_toolkit/configuration.rb
+++ b/lib/deprecation_toolkit/configuration.rb
@@ -6,10 +6,11 @@ module DeprecationToolkit
   class Configuration
     include ActiveSupport::Configurable
 
-    config_accessor(:behavior) { Behaviors::Raise }
     config_accessor(:allowed_deprecations) { [] }
-    config_accessor(:deprecation_path) { "test/deprecations" }
     config_accessor(:attach_to) { [:rails] }
+    config_accessor(:behavior) { Behaviors::Raise }
+    config_accessor(:deprecation_path) { "test/deprecations" }
+    config_accessor(:test_runner) { :minitest }
     config_accessor(:warnings_treated_as_deprecation) { [] }
   end
 end

--- a/lib/deprecation_toolkit/minitest_hook.rb
+++ b/lib/deprecation_toolkit/minitest_hook.rb
@@ -5,13 +5,7 @@ require "minitest"
 module DeprecationToolkit
   module Minitest
     def trigger_deprecation_toolkit_behavior
-      current_deprecations = Collector.new(Collector.deprecations)
-      recorded_deprecations = Collector.load(self)
-      if !recorded_deprecations.flaky? && current_deprecations != recorded_deprecations
-        Configuration.behavior.trigger(self, current_deprecations, recorded_deprecations)
-      end
-    ensure
-      Collector.reset!
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(self)
     end
   end
 end

--- a/lib/deprecation_toolkit/rspec.rb
+++ b/lib/deprecation_toolkit/rspec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "deprecation_toolkit/rspec_plugin"
+
+RSpec.configure do |config|
+  config.after do |example|
+    DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+  end
+end

--- a/lib/deprecation_toolkit/rspec_plugin.rb
+++ b/lib/deprecation_toolkit/rspec_plugin.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module DeprecationToolkit
+  module RSpecPlugin
+    RSpec.configure do |config|
+      config.before(:suite) do
+        case ENV['DEPRECATION_BEHAVIOR']
+        when "r", "record", "record-deprecations"
+          DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Record
+        end
+
+        DeprecationToolkit.add_notify_behavior
+        DeprecationToolkit.attach_subscriber
+      end
+    end
+  end
+end

--- a/lib/deprecation_toolkit/test_triggerer.rb
+++ b/lib/deprecation_toolkit/test_triggerer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module DeprecationToolkit
+  module TestTriggerer
+    def self.trigger_deprecation_toolkit_behavior(test)
+      current_deprecations = DeprecationToolkit::Collector.new(DeprecationToolkit::Collector.deprecations)
+      recorded_deprecations = DeprecationToolkit::Collector.load(test)
+      if !recorded_deprecations.flaky? && current_deprecations != recorded_deprecations
+        DeprecationToolkit::Configuration.behavior.trigger(
+          test, current_deprecations, recorded_deprecations
+        )
+      end
+    ensure
+      DeprecationToolkit::Collector.reset!
+    end
+  end
+end

--- a/spec/deprecation_toolkit/behaviors/disabled_spec.rb
+++ b/spec/deprecation_toolkit/behaviors/disabled_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
+  before do
+    @previous_configuration = DeprecationToolkit::Configuration.behavior
+    DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Disabled
+  end
+
+  after do
+    DeprecationToolkit::Configuration.behavior = @previous_configuration
+  end
+
+  it '.trigger noop any deprecations' do |example|
+    expect do
+      ActiveSupport::Deprecation.warn("Foo")
+      ActiveSupport::Deprecation.warn("Bar")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end.not_to(raise_error)
+  end
+end

--- a/spec/deprecation_toolkit/behaviors/raise_spec.rb
+++ b/spec/deprecation_toolkit/behaviors/raise_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
+  before do
+    @previous_configuration = DeprecationToolkit::Configuration.behavior
+    DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Raise
+  end
+
+  after do
+    DeprecationToolkit::Configuration.behavior = @previous_configuration
+  end
+
+  it ".trigger raises an DeprecationIntroduced error when deprecations are introduced" do |example|
+    expect do
+      ActiveSupport::Deprecation.warn("Foo")
+      ActiveSupport::Deprecation.warn("Bar")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end.to(raise_error(DeprecationToolkit::Behaviors::DeprecationIntroduced))
+  end
+
+  it ".trigger raises a DeprecationRemoved error when deprecations are removed" do |example|
+    expect do
+      ActiveSupport::Deprecation.warn("Foo")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end.to(raise_error(DeprecationToolkit::Behaviors::DeprecationRemoved))
+  end
+
+  it '.trigger raises a DeprecationRemoved when mismatched and less than expected' do |example|
+    expect do
+      ActiveSupport::Deprecation.warn("C")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end.to(raise_error(DeprecationToolkit::Behaviors::DeprecationRemoved))
+  end
+
+  it '.trigger raises a DeprecationMismatch when same number of deprecations are triggered with mismatches' do |example|
+    expect do
+      ActiveSupport::Deprecation.warn("A")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end.to(raise_error(DeprecationToolkit::Behaviors::DeprecationMismatch))
+  end
+
+  it ".trigger does not raise when deprecations are triggered but were already recorded" do |example|
+    expect do
+      ActiveSupport::Deprecation.warn("Foo")
+      ActiveSupport::Deprecation.warn("Bar")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end.not_to(raise_error)
+  end
+
+  it ".trigger does not raise when deprecations are allowed with Regex" do |example|
+    @old_allowed_deprecations = DeprecationToolkit::Configuration.allowed_deprecations
+    DeprecationToolkit::Configuration.allowed_deprecations = [/John Doe/]
+
+    begin
+      ActiveSupport::Deprecation.warn("John Doe")
+      expect do
+        DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+      end.not_to(raise_error)
+    ensure
+      DeprecationToolkit::Configuration.allowed_deprecations = @old_allowed_deprecations
+    end
+  end
+
+  it ".trigger does not raise when deprecations are allowed with Procs" do |example|
+    class_eval <<-RUBY, 'my_file.rb', 1337
+      def deprecation_caller
+        deprecation_callee
+      end
+
+      def deprecation_callee
+        ActiveSupport::Deprecation.warn("John Doe")
+      end
+    RUBY
+
+    old_allowed_deprecations = DeprecationToolkit::Configuration.allowed_deprecations
+    DeprecationToolkit::Configuration.allowed_deprecations = [
+      ->(_, stack) { stack.first.to_s =~ /my_file\.rb/ },
+    ]
+
+    begin
+      deprecation_caller
+      expect do
+        DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+      end.not_to(raise_error)
+    ensure
+      DeprecationToolkit::Configuration.allowed_deprecations = old_allowed_deprecations
+    end
+  end
+end

--- a/spec/deprecation_toolkit/behaviors/record_spec.rb
+++ b/spec/deprecation_toolkit/behaviors/record_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe(DeprecationToolkit::Behaviors::Record) do
+  before do
+    @previous_deprecation_path = DeprecationToolkit::Configuration.deprecation_path
+    @deprecation_path = Dir.mktmpdir
+    @previous_behavior = DeprecationToolkit::Configuration.behavior
+    DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Record
+    DeprecationToolkit::Configuration.deprecation_path = @deprecation_path
+  end
+
+  after do
+    DeprecationToolkit::Configuration.behavior = @previous_behavior
+    DeprecationToolkit::Configuration.deprecation_path = @previous_deprecation_path
+    FileUtils.rm_rf(@deprecation_path)
+  end
+
+  it '.trigger should record deprecations' do |example|
+    expect_deprecations_recorded("Foo", "Bar", example) do
+      ActiveSupport::Deprecation.warn("Foo")
+      ActiveSupport::Deprecation.warn("Bar")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end
+  end
+
+  it ".trigger re-record an existing deprecation file" do |example|
+    expect_deprecations_recorded("Foo", "Bar", example) do
+      ActiveSupport::Deprecation.warn("Foo")
+      ActiveSupport::Deprecation.warn("Bar")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end
+
+    expect_deprecations_recorded("Foo", example) do
+      ActiveSupport::Deprecation.warn("Foo")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end
+  end
+
+  it ".trigger removes the deprecation file when all deprecations were removed" do |example|
+    expect_deprecations_recorded("Foo", example) do
+      ActiveSupport::Deprecation.warn("Foo")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+    end
+
+    expect do
+      expect_deprecations_recorded("Foo", example) do
+        DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+      end
+    end.to(raise_error(Errno::ENOENT))
+  end
+
+  private
+
+  def expect_deprecations_recorded(*deprecation_triggered, example)
+    yield
+
+    recorded = YAML.load_file(
+      "#{@deprecation_path}/deprecation_toolkit/behaviors/record.yml"
+    ).fetch("test_" + example.full_description.underscore.squish.tr(" ", "_"))
+    triggered = deprecation_triggered.map { |msg| "DEPRECATION WARNING: #{msg}" }
+
+    expect(recorded).to(eq(triggered))
+  end
+end

--- a/spec/deprecations/deprecation_toolkit/behaviors/raise.yml
+++ b/spec/deprecations/deprecation_toolkit/behaviors/raise.yml
@@ -1,0 +1,12 @@
+---
+test_deprecation_toolkit/behaviors/raise_.trigger_raises_a_deprecation_removed_error_when_deprecations_are_removed:
+- 'DEPRECATION WARNING: Foo'
+- 'DEPRECATION WARNING: Bar'
+test_deprecation_toolkit/behaviors/raise_.trigger_raises_a_deprecation_removed_when_mismatched_and_less_than_expected:
+- 'DEPRECATION WARNING: A'
+- 'DEPRECATION WARNING: B'
+test_deprecation_toolkit/behaviors/raise_.trigger_raises_a_deprecation_mismatch_when_same_number_of_deprecations_are_triggered_with_mismatches:
+- 'DEPRECATION WARNING: C'
+test_deprecation_toolkit/behaviors/raise_.trigger_does_not_raise_when_deprecations_are_triggered_but_were_already_recorded:
+- 'DEPRECATION WARNING: Foo'
+- 'DEPRECATION WARNING: Bar'

--- a/spec/rspec/plugin_env_options_spec.rb
+++ b/spec/rspec/plugin_env_options_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This needs to be set before we require `spec_helper` to simulate setting an ENV when running a spec like:
+# `DEPRECATION_BEHAVIOR="record" bundle exec rspec path/to/spec.rb`
+ENV['DEPRECATION_BEHAVIOR'] = "record"
+
+require 'spec_helper'
+
+RSpec.describe("DeprecationToolkit::RSpecPlugin ENV options") do
+  it 'should set the behavior to `Record` when ENV variable is set' do
+    expect(DeprecationToolkit::Configuration.behavior).to(eq(DeprecationToolkit::Behaviors::Record))
+  end
+end

--- a/spec/rspec/plugin_spec.rb
+++ b/spec/rspec/plugin_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(DeprecationToolkit::RSpecPlugin) do
+  it "should add `notify` behavior to the deprecations behavior list" do
+    behavior = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:notify]
+
+    expect(ActiveSupport::Deprecation.behavior).to(include(behavior))
+  end
+
+  it "doesn't remove previous deprecation behaviors" do
+    behavior = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:silence]
+    ActiveSupport::Deprecation.behavior = behavior
+
+    expect(ActiveSupport::Deprecation.behavior).to(include(behavior))
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require "deprecation_toolkit"
+require "deprecation_toolkit/rspec_plugin"
+require "active_support/all"
+
+DeprecationToolkit::Configuration.test_runner = :rspec
+DeprecationToolkit::Configuration.deprecation_path = "spec/deprecations"
+ActiveSupport::Deprecation.behavior = :silence
+
+RSpec.configure do |config|
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with(:rspec) do |c|
+    c.syntax = :expect
+  end
+end

--- a/test/deprecation_toolkit/configuration_test.rb
+++ b/test/deprecation_toolkit/configuration_test.rb
@@ -19,5 +19,9 @@ module DeprecationToolkit
     test ".attach_to is by default set to `rails`" do
       assert_equal [:rails], Configuration.attach_to
     end
+
+    test ".test_runner is by default set to `minitest`" do
+      assert_equal :minitest, Configuration.test_runner
+    end
   end
 end


### PR DESCRIPTION
This is a first pass at closing #17 by adding support for RSpec.

## Setup
For Rspec users the setup is slightly different than minitest.

(In rails_helper.rb or spec_helper.rb)
```ruby
# Add Deprecation Toolkit library
require 'deprecation_toolkit/rspec'

RSpec.configure do |config|
  config.deprecation_behavior = :raise
end
```

Also it's worth noting that RSpec doesn't support adding custom flags when running tests. So you won't be able to add `--record-deprecations` when running your specs, but instead recording / raising  would have to be changed at the config level (like above).

For that I've made a small DSL so you can pass in a symbol of (`:raise`, `:record`, or :`disabled`).


## Still to do
I mostly want to open this PR to get some early feedback and see if this approach makes sense.  I still need to write some tests for this!




