### PR TITLE
Add a way to mark a test as flaky:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## master (unreleased)
+* [#38](https://github.com/Shopify/deprecation_toolkit/pull/38): Add a way to mark test as flaky. (@Edouard-chin)
 
 ## 1.2.1 (2019-01-09)
 

--- a/lib/deprecation_toolkit/collector.rb
+++ b/lib/deprecation_toolkit/collector.rb
@@ -59,5 +59,9 @@ module DeprecationToolkit
 
       difference
     end
+
+    def flaky?
+      size == 1 && deprecations.first['flaky'] == true
+    end
   end
 end

--- a/lib/deprecation_toolkit/minitest_hook.rb
+++ b/lib/deprecation_toolkit/minitest_hook.rb
@@ -7,7 +7,7 @@ module DeprecationToolkit
     def trigger_deprecation_toolkit_behavior
       current_deprecations = Collector.new(Collector.deprecations)
       recorded_deprecations = Collector.load(self)
-      if current_deprecations != recorded_deprecations
+      if !recorded_deprecations.flaky? && current_deprecations != recorded_deprecations
         Configuration.behavior.trigger(self, current_deprecations, recorded_deprecations)
       end
     ensure

--- a/test/deprecation_toolkit/behaviors/raise_test.rb
+++ b/test/deprecation_toolkit/behaviors/raise_test.rb
@@ -82,11 +82,18 @@ module DeprecationToolkit
         end
       end
 
+      test ".trigger does not raise when test is flaky" do
+        assert_nothing_raised do
+          ActiveSupport::Deprecation.warn("Foo")
+          ActiveSupport::Deprecation.warn("Bar")
+        end
+      end
+
       def trigger_deprecation_toolkit_behavior
         super
         flunk if defined?(@expected_exception)
       rescue DeprecationIntroduced, DeprecationRemoved, DeprecationMismatch => e
-        assert_equal(@expected_exception, e.class)
+        assert_equal(@expected_exception, e.class, e.message)
       end
     end
   end

--- a/test/deprecations/deprecation_toolkit/behaviors/raise_test.yml
+++ b/test/deprecations/deprecation_toolkit/behaviors/raise_test.yml
@@ -10,3 +10,5 @@ test_.trigger_raises_a_DeprecationRemoved_when_less_deprecations_than_expected_a
 - 'DEPRECATION_WARNING: B'
 test_.trigger_raises_a_DeprecationMismatch_when_same_number_of_deprecations_are_triggered_with_mismatches:
 - 'DEPRECATION_WARNING: C'
+test_.trigger_does_not_raise_when_test_is_flaky:
+  - flaky: true


### PR DESCRIPTION
Add a way to mark a test as flaky:

- The deprecations triggered by some test is different (either they
  get triggered in a different order or they don't trigger the same
  amount of deprecations between multiple test runs).

  By definition the test is flaky. Even if at the end the test passes,
  the fact that sometime a method run and sometime it doesn't is the
  sign of flakyness.
  The deprecation toolkit can't deal with that.

  This PR adds a way to mark a test as flaky so that the deprecations
  triggered by the test will be ignored.
  The syntax is like that:

  ```YAML
  my_test:
    - flaky: true
  ```