### PR TITLE
RSpec integration causes collisions when recording deprecations generated by shared examples

### DIFF
--- a/lib/deprecation_toolkit/configuration.rb
+++ b/lib/deprecation_toolkit/configuration.rb
@@ -12,5 +12,6 @@ module DeprecationToolkit
     config_accessor(:deprecation_path) { "test/deprecations" }
     config_accessor(:test_runner) { :minitest }
     config_accessor(:warnings_treated_as_deprecation) { [] }
+    config_accessor(:use_legacy_rspec_recorded_deprecations_path) { false }
   end
 end

--- a/lib/deprecation_toolkit/read_write_helper.rb
+++ b/lib/deprecation_toolkit/read_write_helper.rb
@@ -49,7 +49,7 @@ module DeprecationToolkit
 
       path =
         if DeprecationToolkit::Configuration.test_runner == :rspec
-          test.location_rerun_argument.sub(%r{^./spec/}, "").sub(/_spec.rb:\d*$/, "")
+          rspec_recorded_deprecations_path(test)
         else
           test.class.name.underscore
         end
@@ -68,6 +68,14 @@ module DeprecationToolkit
         "test_" + test.full_description.underscore.squish.tr(" ", "_")
       else
         test.name
+      end
+    end
+
+    def rspec_recorded_deprecations_path(test)
+      if DeprecationToolkit::Configuration.use_legacy_rspec_recorded_deprecations_path
+        test.example_group.file_path.sub(%r{^./spec/}, "").sub(/_spec.rb$/, "")
+      else
+        test.location_rerun_argument.sub(%r{^./spec/}, "").sub(/_spec.rb:\d*$/, "")
       end
     end
   end

--- a/lib/deprecation_toolkit/read_write_helper.rb
+++ b/lib/deprecation_toolkit/read_write_helper.rb
@@ -49,7 +49,7 @@ module DeprecationToolkit
 
       path =
         if DeprecationToolkit::Configuration.test_runner == :rspec
-          test.example_group.file_path.sub(%r{^./spec/}, "").sub(/_spec.rb$/, "")
+          test.location_rerun_argument.sub(%r{^./spec/}, "").sub(/_spec.rb:\d*$/, "")
         else
           test.class.name.underscore
         end

--- a/spec/deprecation_toolkit/behaviors/record_spec.rb
+++ b/spec/deprecation_toolkit/behaviors/record_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe(DeprecationToolkit::Behaviors::Record) do
     end.to(raise_error(Errno::ENOENT))
   end
 
+  include_examples "shared examples", "deprecation_toolkit/behaviors/record.yml"
+
   private
 
   def expect_deprecations_recorded(*deprecation_triggered, example)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require "deprecation_toolkit"
 require "deprecation_toolkit/rspec_plugin"
 require "active_support/all"
 
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
 DeprecationToolkit::Configuration.test_runner = :rspec
 DeprecationToolkit::Configuration.deprecation_path = "spec/deprecations"
 ActiveSupport::Deprecation.behavior = :silence

--- a/spec/support/shared/shared_examples.rb
+++ b/spec/support/shared/shared_examples.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples("shared examples") do |deprecation_path|
+  context "nested shared context" do
+    it "uses the spec filename to record the deprecation" do |example|
+      ActiveSupport::Deprecation.warn("Foo")
+
+      DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
+
+      recorded = YAML.load_file("#{@deprecation_path}/#{deprecation_path}")
+        .fetch("test_" + example.full_description.underscore.squish.tr(" ", "_"))
+
+      expect(recorded).to(eq(["DEPRECATION WARNING: Foo"]))
+    end
+  end
+end

--- a/test/deprecation_toolkit/configuration_test.rb
+++ b/test/deprecation_toolkit/configuration_test.rb
@@ -23,5 +23,9 @@ module DeprecationToolkit
     test ".test_runner is by default set to `minitest`" do
       assert_equal :minitest, Configuration.test_runner
     end
+
+    test ".use_legacy_rspec_recorded_deprecations_path is by default set to `false`" do
+      assert_equal false, Configuration.use_legacy_rspec_recorded_deprecations_path
+    end
   end
 end


### PR DESCRIPTION
I have discovered what I believe is a bug in the RSpec integration. It comes up when using shared examples:

1. Have a shared example in a separate file that defines a nested context, e.g.

   ```ruby
   # spec/support/shared/shared_example.rb
   RSpec.shared_examples "shared example" do
     context "nested shared context" do
       it "breaks here" do
         # call some other app code that raises deprecations
       end
     end
   end
   ```

2. Now include the shared examples in two different specs:

   ```ruby
   # spec/first_file_spec.rb
   include_examples "shared example"
   ```

   ```ruby
   # spec/second_file_spec.rb
   include_examples "shared example"
   ```

3. Both first_file_spec.rb and second_file_spec.rb will generate deprecations, but the record behavior will record these deprecations as though they were generated by the `spec/support/shared/shared_example.rb` file, as opposed to either of the spec files. I would expect that the deprecations would be attributed to the spec files, not the shared example file.

Since shared examples can take parameters, different usages of shared examples could generate different deprecations. Because the RSpec integration links all deprecations generated by all usages of the shared examples to the same file, the different lists of deprecations clobber each other when recording. Then with the raise behavior, the usages that generate different deprecations than the one that won out when recording cause exceptions.

The solution I came up with, and what is implemented in this PR, is to modify `recorded_deprecations_path` when the test runner is RSpec to use [`location_rerun_argument`](https://github.com/rspec/rspec-core/blob/77dbc84657c5dc45e07a7fe0f5b02b4caeb6c9ad/lib/rspec/core/example.rb#L96) instead of `file_path`. The difference is that, when the shared example is in a nested context, the context will report its file path as the file that defined the shared example, whereas the `location_rerun_argument` will point to the specific spec file that used the shared example.

The biggest problem I could see with this approach was that it would be breaking a change for current users of the RSpec integration, because the gem would now expect to find their recordings in a different location. To maintain backwards compatibility with current users of the RSpec integration, I introduced a new config option called `use_legacy_rspec_recorded_deprecations_path`, which is defaulted to `false`. When set to `true`, the previous behavior of `recorded_deprecations_path` is used instead of the new behavior. In the release notes for the gem, we can recommend to current users of the RSpec integration to set this parameter to `true` until they can re-record deprecations.