### PR TITLE
Fix Minitest plugin kicking in when it shouldn't:

### DIFF
--- a/lib/minitest/deprecation_toolkit_plugin.rb
+++ b/lib/minitest/deprecation_toolkit_plugin.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'deprecation_toolkit'
-
 module Minitest
   extend self
 
@@ -12,11 +10,20 @@ module Minitest
   end
 
   def plugin_deprecation_toolkit_init(options)
+    return unless using_bundler?
+
+    require 'deprecation_toolkit'
     if options[:record_deprecations]
       DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Record
     end
 
     DeprecationToolkit.add_notify_behavior
     DeprecationToolkit.attach_subscriber
+  end
+
+  private
+
+  def using_bundler?
+    ENV['BUNDLE_GEMFILE']
   end
 end

--- a/test/minitest/deprecation_toolkit_plugin_test.rb
+++ b/test/minitest/deprecation_toolkit_plugin_test.rb
@@ -60,5 +60,21 @@ module Minitest
 
       assert_equal 1, error.message.scan("DEPRECATION WARNING: Deprecated!").count
     end
+
+    test ".plugin_deprecation_toolkit_init doesn't init plugin when outside bundler context" do
+      begin
+        notify_behavior = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:notify]
+        old_bundle_gemfile = ENV['BUNDLE_GEMFILE']
+        ENV.delete('BUNDLE_GEMFILE')
+
+        ActiveSupport::Deprecation.behavior.delete(notify_behavior)
+        Minitest.plugin_deprecation_toolkit_init({})
+
+        refute_includes(ActiveSupport::Deprecation.behavior, notify_behavior)
+      ensure
+        ENV['BUNDLE_GEMFILE'] = old_bundle_gemfile
+        ActiveSupport::Deprecation.behavior << notify_behavior
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix Minitest plugin kicking in when it shouldn't:

- When the deprecation toolkit get installed, it ends up in
  somewhere in the GEM_PATH.

  If you have a project that doesn't use bundler (like minitest itself),
  then all minitest plugins found in the `GEM_PATH` will get loaded.
  This is problematic because we don't want to run the deprecation_toolkit
  on projects that didn't specify it.

  This problem only happens on project not using bundler, because
  otherwise, gems not part of the snapshots don't end up in the
  load_path and thus the minitest plugin don't kick in.