### PR TITLE
Handle multipart warnings

### DIFF
--- a/test/deprecation_toolkit/warning_test.rb
+++ b/test/deprecation_toolkit/warning_test.rb
@@ -63,5 +63,22 @@ module DeprecationToolkit
         warn 'Test warn works correctly'
       end
     end
+
+    if RUBY_VERSION >= '2.5'
+      test 'Ruby 2.7 two-part keyword argument warning are joined together' do
+        Configuration.warnings_treated_as_deprecation = [/Using the last argument as keyword parameters/]
+
+        error = assert_raises Behaviors::DeprecationIntroduced do
+          warn "/path/to/caller.rb:1: warning: Using the last argument as keyword parameters is deprecated; " \
+            "maybe ** should be added to the call"
+          warn "/path/to/calleee.rb:1: warning: The called method `method_name' is defined here"
+
+          trigger_deprecation_toolkit_behavior
+        end
+
+        assert_match(/Using the last argument as keyword parameters/, error.message)
+        assert_match(/The called method/, error.message)
+      end
+    end
   end
 end


### PR DESCRIPTION
As explained in the code comments, that warning is sent in two part.

The problem is that if you raise on the first or second part, the warning becomes very hard to understand and deal with, so it's preferable to join the two parts together and consider them as a single warning.

