### PR TITLE
Ensures ActiveSupport is required

### DIFF
--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -34,8 +34,7 @@ module DeprecationToolkit
   end
 end
 
-unless defined?(RSpec)
-  require "deprecation_toolkit/minitest_hook"
-end
+require "deprecation_toolkit/minitest_hook" unless defined? RSpec
+require "active_support"
 
 require "deprecation_toolkit/warning"


### PR DESCRIPTION
When using the toolkit outside of Rails against MiniTest users will
receive the following error:

```
deprecation_toolkit/lib/deprecation_toolkit.rb:20:in
`add_notify_behavior': uninitialized constant
ActiveSupport::Deprecation (NameError)
```

This will raise even when not using `ActiveSupport::Deprecation` (i.e.
`warn 'Deprecated: this is my deprecation'`) as all deprecations are
then passed through `ActiveSupport::Deprecation` in the gem.

This PR requires the ActiveSupport dependency if not already defined to
cover off these cases.

Signed-off-by: Nick Schwaderer <nschwaderer@chef.io>