### PR TITLE
Prepare 2.0.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main (unreleased)
 
+## 2.0.0 (2022-03-16)
+
 * [#58](https://github.com/Shopify/deprecation_toolkit/pull/58): Drop support for Ruby < 2.6 & Active Support < 5.2. (@sambostock)
 * [#58](https://github.com/Shopify/deprecation_toolkit/pull/58): Ensure compatibility with Rails 7. (@sambostock)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,21 @@
 * [#58](https://github.com/Shopify/deprecation_toolkit/pull/58): Drop support for Ruby < 2.6 & Active Support < 5.2. (@sambostock)
 * [#58](https://github.com/Shopify/deprecation_toolkit/pull/58): Ensure compatibility with Rails 7. (@sambostock)
 
+## 1.5.1 (2020-04-28)
+
+* [#46](https://github.com/Shopify/deprecation_toolkit/pull/46): Handle another two part Ruby 2.7 keyword argument deprecation warning. (@casperisfine)
+
+## 1.5.0 (2020-04-14)
+
+* [#42](https://github.com/Shopify/deprecation_toolkit/pull/42): Fix Minitest plugin kicking in when it shouldn't. (@Edouard-chin)
+* [#45](https://github.com/Shopify/deprecation_toolkit/pull/45): Handle two part Ruby 2.7 keyword argument deprecation warning. (@casperisfine)
+
 ## 1.4.0 (2019-04-29)
+
 * [#37](https://github.com/Shopify/deprecation_toolkit/pull/37): Add Rspec support. (@andrewmarkle)
 
 ## 1.3.0 (2019-02-28)
+
 * [#38](https://github.com/Shopify/deprecation_toolkit/pull/38): Add a way to mark test as flaky. (@Edouard-chin)
 * [#39](https://github.com/Shopify/deprecation_toolkit/pull/39): Introduced a way to help recording massive amount of deprecations. (@Edouard-chin)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deprecation_toolkit (1.5.1)
+    deprecation_toolkit (2.0.0)
       activesupport (>= 5.2)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.2)
+    activesupport (7.0.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+# Contribution to Deprecation Toolkit
+
+## Releasing a new version
+
+1. Audit PRs and commits merged since the last release, ensuring **all user fancing changes are documented** in `CHANGELOG.md`.
+2. Based on the changes, determine whether to increment the major, minor, or patch version, adhering to [Semantic Versioning][semver].
+3. Update the gem version string accordingly in `lib/deprecation_toolkit/version.rb`.
+4. Run `bundle install` to update the `Gemfile.lock`.
+5. Insert a new heading in `CHANGELOG.md` containing the version identifier and expected release date (e.g. `## 1.2.3 (1999-12-31)`).
+6. Commit changes on a new branch and open a PR.
+7. **Draft** a [new release][github-new-release] on GitHub, but **do not publish it yet**.
+8. Once you have received approval on your PR, merge it into `main`.
+9. Deploy using the [ShipIt][shipit] UI, and **verify** the new version is available on [RubyGems][rubygems].
+10. Publish the drafted release, tagging the deployed commit (should be `HEAD` of the `main` branch) with a tag of the form `vMAJOR.MINOR.PATCH`.
+
+If something goes wrong during the deploy process, address it and tag whatever commit was successfully deployed as that version.
+
+[semver]: https://semver.org
+[github-new-release]: https://github.com/Shopify/deprecation_toolkit/releases/new
+[shipit]: https://shipit.shopify.io/shopify/deprecation_toolkit/rubygems
+[rubygems]: https://rubygems.org/gems/deprecation_toolkit/versions

--- a/lib/deprecation_toolkit/version.rb
+++ b/lib/deprecation_toolkit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeprecationToolkit
-  VERSION = "1.5.1"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
This PR updates the gem version to 2.0.0 ahead of release.

It also adds release notes, since there weren't any, and incidentally bumps the development version of `activesupport` (due to running `bundle install`) by one security patch version.

As per release instructions...

### ⚠️ Before Merging
- [x] Draft new release in GitHub

### ⚠️ After Merging
- [ ] Deploy via Shipit and verify in Rubygems
- [ ] Publish [drafted release](https://github.com/Shopify/deprecation_toolkit/releases/edit/untagged-b20b76fe5f9e3eb1eb8c)