### PR TITLE
Normalize paths in deprecation messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }}
     strategy:
+      fail-fast: false
       matrix:
         gemfile: [gemfiles/activesupport_5.2.gemfile, gemfiles/activesupport_6.0.gemfile, gemfiles/activesupport_6.1.gemfile, gemfiles/activesupport_7.0.gemfile, gemfiles/activesupport_edge.gemfile]
         ruby: ["2.6", "2.7", "3.0", "3.1"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main (unreleased)
 
+* [#60](https://github.com/Shopify/deprecation_toolkit/pull/60): Normalize paths in deprecation messages. (@sambostock)
+
 ## 2.0.0 (2022-03-16)
 
 * [#58](https://github.com/Shopify/deprecation_toolkit/pull/58): Drop support for Ruby < 2.6 & Active Support < 5.2. (@sambostock)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,38 @@ This setting accepts an array of regular expressions. To match on all warnings, 
 DeprecationToolkit::Configuration.warnings_treated_as_deprecation = [//]
 ```
 
+### 🔨 `#DeprecationToolkit::Configuration#message_normalizers`
+
+Deprecation Toolkit allows the normalization of deprecation warnings by registering message normalizers.
+
+Out-of-the-box, various path normalizers are included, to ensure that any paths included in deprecation warnings are consistent from machine to machine (see [`lib/deprecation_toolkit/configuration.rb`](lib/deprecation_toolkit/configuration.rb) for details).
+
+### Customizing normalization
+
+Additional normalizers can be added by appending then to the array:
+
+```ruby
+DeprecationToolkit::Configuration.message_normalizers << ->(msg) { msg.downcase }
+```
+
+Normalizers are expected to respond to `.call`, accepting a `String` and returning a normalized `String`, and are applied in order of registration.
+
+If you wish to normalize a custom path, you can create your own `DeprecationToolkit::PathPrefixNormalizer`:
+
+```ruby
+DeprecationToolkit::Configuration.message_normalizers <<
+  DeprecationToolkit::PathPrefixNormalizer.new(
+    '/path/to/something',
+    replacement: 'optional replacement string',
+  )
+```
+
+You may optionally disable any or all normalizers by mutating or replacing the array.
+
+```ruby
+DeprecationToolkit::Configuration.message_normalizers = [] # remove all normalizers
+```
+
 ## RSpec
 
 By default Deprecation Toolkit uses Minitest as its test runner. To use Deprecation Toolkit with RSpec you'll have to configure it.

--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -8,6 +8,7 @@ module DeprecationToolkit
   autoload :DeprecationSubscriber,     "deprecation_toolkit/deprecation_subscriber"
   autoload :Configuration,             "deprecation_toolkit/configuration"
   autoload :Collector,                 "deprecation_toolkit/collector"
+  autoload :PathPrefixNormalizer,      "deprecation_toolkit/path_prefix_normalizer"
   autoload :ReadWriteHelper,           "deprecation_toolkit/read_write_helper"
   autoload :TestTriggerer,             "deprecation_toolkit/test_triggerer"
 

--- a/lib/deprecation_toolkit/configuration.rb
+++ b/lib/deprecation_toolkit/configuration.rb
@@ -18,6 +18,7 @@ module DeprecationToolkit
 
       normalizers << PathPrefixNormalizer.new(Rails.root) if defined?(Rails)
       normalizers << PathPrefixNormalizer.new(Bundler.root) if defined?(Bundler)
+      normalizers << PathPrefixNormalizer.new(Dir.pwd)
 
       if defined?(Gem)
         Gem.loaded_specs.each_value do |spec|
@@ -37,8 +38,6 @@ module DeprecationToolkit
       rescue LoadError
         # skip normalizing ruby internal paths
       end
-
-      normalizers << PathPrefixNormalizer.new(Dir.pwd)
 
       normalizers
     end

--- a/lib/deprecation_toolkit/configuration.rb
+++ b/lib/deprecation_toolkit/configuration.rb
@@ -12,5 +12,35 @@ module DeprecationToolkit
     config_accessor(:deprecation_path) { "test/deprecations" }
     config_accessor(:test_runner) { :minitest }
     config_accessor(:warnings_treated_as_deprecation) { [] }
+
+    config_accessor(:message_normalizers) do
+      normalizers = []
+
+      normalizers << PathPrefixNormalizer.new(Rails.root) if defined?(Rails)
+      normalizers << PathPrefixNormalizer.new(Bundler.root) if defined?(Bundler)
+
+      if defined?(Gem)
+        Gem.loaded_specs.each_value do |spec|
+          normalizers << PathPrefixNormalizer.new(spec.bin_dir, replacement: "<GEM_BIN_DIR:#{spec.name}>")
+          normalizers << PathPrefixNormalizer.new(spec.extension_dir, replacement: "<GEM_EXTENSION_DIR:#{spec.name}>")
+          normalizers << PathPrefixNormalizer.new(spec.gem_dir, replacement: "<GEM_DIR:#{spec.name}>")
+        end
+        normalizers << PathPrefixNormalizer.new(*Gem.path, replacement: "<GEM_PATH>")
+      end
+
+      begin
+        require "rbconfig"
+        normalizers << PathPrefixNormalizer.new(
+          *RbConfig::CONFIG.values_at("prefix", "sitelibdir", "rubylibdir"),
+          replacement: "<RUBY_INTERNALS>",
+        )
+      rescue LoadError
+        # skip normalizing ruby internal paths
+      end
+
+      normalizers << PathPrefixNormalizer.new(Dir.pwd)
+
+      normalizers
+    end
   end
 end

--- a/lib/deprecation_toolkit/path_prefix_normalizer.rb
+++ b/lib/deprecation_toolkit/path_prefix_normalizer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+module DeprecationToolkit
+  class PathPrefixNormalizer
+    attr_reader :path_prefixes, :replacement
+
+    def initialize(*path_prefixes, replacement: "")
+      @path_prefixes = path_prefixes.compact.map do |path_prefix|
+        raise ArgumentError, "path prefixes must be absolute: #{path_prefix}" unless Pathname.new(path_prefix).absolute?
+
+        ending_in_separator(path_prefix)
+      end.sort_by { |path| -path.length }
+      @replacement = replacement.empty? ? replacement : ending_in_separator(replacement)
+    end
+
+    def call(message)
+      message.gsub(pattern, replacement)
+    end
+
+    def to_s
+      "s#{pattern}#{replacement}"
+    end
+
+    def pattern
+      # Naively anchor to the start of a path.
+      # The last character of each segment of a path is likely to match /\w/.
+      # Therefore, if the preceeding character does not match /w/, we're probably not in in the middle of a path.
+      # e.g. In a containerized environment, we may be given `/app` as a path prefix (perhaps from Rails.root).
+      #      Given the following path:                       `/app/components/foo/app/models/bar.rb`,
+      #      we should replace the prefix, producing:             `components/foo/app/models/bar.rb`,
+      #      without corrupting other occurences:                 `components/foomodels/bar.rb`
+      @pattern ||= /(?<!\w)#{Regexp.union(path_prefixes)}/
+    end
+
+    def ending_in_separator(path)
+      File.join(path, "")
+    end
+  end
+end

--- a/test/deprecation_toolkit/path_prefix_normalizer_test.rb
+++ b/test/deprecation_toolkit/path_prefix_normalizer_test.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module DeprecationToolkit
+  class PathPrefixNormalizerTest < ActiveSupport::TestCase
+    test "can strip a single path prefix" do
+      prefix = File.join("", "a")
+      normalizer = PathPrefixNormalizer.new(prefix)
+
+      full_path = File.join("", "a", "b", "c")
+      normalized_path = File.join("b", "c")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "can strip multiple path prefixes" do
+      prefixes = [File.join("", "a"), File.join("", "d")]
+      normalizer = PathPrefixNormalizer.new(*prefixes)
+
+      full_path = File.join("", "a", "b", "c")
+      normalized_path = File.join("b", "c")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+
+      full_path = File.join("", "d", "e", "f")
+      normalized_path = File.join("e", "f")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "multiple path prefixes are replaced individually, not in succession" do
+      prefixes = [File.join("", "a"), File.join("", "d")]
+      normalizer = PathPrefixNormalizer.new(*prefixes)
+
+      full_path = File.join("", "a", "b", "c", "d", "e", "f")
+      normalized_path = File.join("b", "c", "d", "e", "f")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "replacement is customizable" do
+      prefix = File.join("", "a")
+      normalizer = PathPrefixNormalizer.new(prefix, replacement: File.join("eh", ""))
+
+      full_path = File.join("", "a", "b", "c")
+      normalized_path = File.join("eh", "b", "c")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "path separator is appended to replacement if not present" do
+      prefix = File.join("", "a")
+      normalizer = PathPrefixNormalizer.new(prefix, replacement: "eh")
+
+      full_path = File.join("", "a", "b", "c")
+      normalized_path = File.join("eh", "b", "c")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "path separator is not appended to empty replacement" do
+      prefix = File.join("", "a")
+      normalizer = PathPrefixNormalizer.new(prefix, replacement: "")
+
+      full_path = File.join("", "a", "b", "c")
+      normalized_path = File.join("b", "c")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "given prefix is extended to include trailing separator if not present" do
+      prefix = File.join("", "a")
+      normalizer = PathPrefixNormalizer.new(prefix)
+
+      full_path = File.join("", "a", "b", "c")
+      normalized_path = File.join("b", "c")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "if given prefix already includes trailing separator, it is not duplicated" do
+      prefix = File.join("", "a", "")
+      normalizer = PathPrefixNormalizer.new(prefix)
+
+      full_path = File.join("", "a", "b", "c")
+      normalized_path = File.join("b", "c")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "only path prefixes are replaced, not infixes or suffixes" do
+      prefixes = [File.join("", "a"), File.join("", "b"), File.join("", "c")]
+      normalizer = PathPrefixNormalizer.new(*prefixes)
+
+      full_path = File.join("", "a", "b", "c", "c", "b", "a")
+      normalized_path = File.join("b", "c", "c", "b", "a")
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "paths are normalized even if in the middle of the given string" do
+      prefix = File.join("", "a")
+      normalizer = PathPrefixNormalizer.new(prefix)
+
+      original_message = "The code in #{File.join("", "a", "b", "c")} on line 1 is deprecated!"
+      normalized_message = "The code in #{File.join("b", "c")} on line 1 is deprecated!"
+
+      assert_equal normalized_message, normalizer.call(original_message)
+    end
+
+    test "relative paths are not accepted" do
+      prefix = File.join("a", "", "b")
+
+      error = assert_raises(ArgumentError) do
+        PathPrefixNormalizer.new(prefix)
+      end
+
+      assert_equal "path prefixes must be absolute: #{prefix}", error.message
+    end
+
+    test "multiple paths in given string are normalized" do
+      prefix = File.join("", "a")
+      normalizer = PathPrefixNormalizer.new(prefix)
+
+      original_message = "There are deprecations in #{File.join("", "a", "b")} and #{File.join("", "a", "c")}"
+      normalized_message = "There are deprecations in b and c"
+
+      assert_equal normalized_message, normalizer.call(original_message)
+    end
+
+    test "matches are as long as possible" do
+      prefixes = [File.join("", "a"), File.join("", "a", "b")]
+      normalizer = PathPrefixNormalizer.new(*prefixes)
+
+      full_path = File.join("", "a", "b", "c")
+      normalized_path = "c"
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+
+    test "nil prefixes are ignored" do
+      prefixes = [File.join("", "a"), nil]
+      normalizer = PathPrefixNormalizer.new(*prefixes)
+
+      full_path = File.join("", "a", "b")
+      normalized_path = "b"
+
+      assert_equal normalized_path, normalizer.call(full_path)
+    end
+  end
+end

--- a/test/deprecation_toolkit/warning_test.rb
+++ b/test/deprecation_toolkit/warning_test.rb
@@ -59,9 +59,13 @@ module DeprecationToolkit
     end
 
     test "warn works as usual when no warnings are treated as deprecation" do
-      assert_nothing_raised do
-        warn "Test warn works correctly"
+      std_out, stderr = capture_io do
+        assert_nothing_raised do
+          warn("Test warn works correctly")
+        end
       end
+      assert_empty std_out
+      assert_equal "Test warn works correctly\n", stderr
     end
 
     test "Ruby 2.7 two-part keyword argument warning are joined together" do

--- a/test/deprecation_toolkit/warning_test.rb
+++ b/test/deprecation_toolkit/warning_test.rb
@@ -82,5 +82,128 @@ module DeprecationToolkit
       assert_match(/Using the last argument as keyword parameters/, error.message)
       assert_match(/The called method/, error.message)
     end
+
+    test "'Ruby 2.7 last argument as keyword parameters' real deprecation warning is handled with normalized paths" do
+      Configuration.warnings_treated_as_deprecation = [/Using the last argument as keyword parameters/]
+
+      error = assert_raises(Behaviors::DeprecationIntroduced) do
+        warn("#{Dir.pwd}/path/to/caller.rb:1: warning: Using the last argument as keyword parameters is deprecated; " \
+          "maybe ** should be added to the call")
+        warn("#{Dir.pwd}/path/to/callee.rb:1: warning: The called method `method_name' is defined here")
+
+        trigger_deprecation_toolkit_behavior
+      end
+
+      assert_match(%r{^DEPRECATION WARNING: path/to/caller\.rb:1: warning: Using the last},
+        error.message)
+      assert_match(%r{^path/to/callee\.rb:1: warning: The called method}, error.message)
+    end
+
+    test "`assert_nil` real deprecation warning is handled with normalized paths" do
+      Configuration.warnings_treated_as_deprecation = [/Use assert_nil if expecting nil/]
+
+      error = assert_raises(Behaviors::DeprecationIntroduced) do
+        warn("Use assert_nil if expecting nil from #{Dir.pwd}/path/to/file.rb:1. This will fail in Minitest 6.")
+
+        trigger_deprecation_toolkit_behavior
+      end
+
+      assert_match(
+        %r{^DEPRECATION WARNING: Use assert_nil if expecting nil from path/to/file\.rb:1}, error.message
+      )
+    end
+
+    test "the path to warn itself is handled too" do
+      Configuration.warnings_treated_as_deprecation = [/boom/]
+
+      error = assert_raises(Behaviors::DeprecationIntroduced) do
+        warn("boom")
+
+        trigger_deprecation_toolkit_behavior
+      end
+
+      assert_includes(error.message, <<~MESSAGE.chomp)
+        DEPRECATION WARNING: boom
+         (called from call at <RUBY_INTERNALS>/rubygems/core_ext/kernel_warn.rb:22)
+      MESSAGE
+    end
+
+    test "Rails.root is normalized in deprecation messages" do
+      rails_stub = Object.new
+      rails_stub.define_singleton_method(:inspect) { "Rails (stub)" }
+      rails_stub.define_singleton_method(:root) { "/path/to/rails/root" }
+
+      original_rails = defined?(::Rails) && ::Rails
+      Object.const_set(:Rails, rails_stub)
+
+      assert_normalizes(
+        from: "#{Rails.root}/app/models/whatever.rb",
+        to: "app/models/whatever.rb",
+      )
+    ensure
+      if original_rails.nil?
+        Object.send(:remove_const, :Rails)
+      else
+        Object.const_set(:Rails, original_rails)
+      end
+    end
+
+    test "Bundler.root is normalized in deprecation messages" do
+      assert_normalizes(
+        from: "#{Bundler.root}/lib/whatever.rb",
+        to: "lib/whatever.rb",
+      )
+    end
+
+    test "Gem spec gem_dirs are normalized in deprecation messages" do
+      spec = Gem.loaded_specs.each_value.first
+      assert_normalizes(
+        from: "#{spec.gem_dir}/lib/whatever.rb",
+        to: "<GEM_DIR:#{spec.name}>/lib/whatever.rb",
+      )
+    end
+
+    test "Gem spec extension_dirs are normalized in deprecation messages" do
+      spec = Gem.loaded_specs.each_value.first
+      assert_normalizes(
+        from: "#{spec.extension_dir}/lib/whatever.rb",
+        to: "<GEM_EXTENSION_DIR:#{spec.name}>/lib/whatever.rb",
+      )
+    end
+
+    test "Gem spec bin_dirs are normalized in deprecation messages" do
+      spec = Gem.loaded_specs.each_value.first
+      assert_normalizes(
+        from: "#{spec.bin_dir}/lib/whatever.rb",
+        to: "<GEM_BIN_DIR:#{spec.name}>/lib/whatever.rb",
+      )
+    end
+
+    test "Gem paths are normalized in deprecation messages" do
+      paths = Gem.path
+      assert_normalizes(
+        from: paths.map.with_index { |path, index| "#{path}/file-#{index}" }.join("\n"),
+        to: Array.new(paths.length) { |index| "<GEM_PATH>/file-#{index}" }.join("\n"),
+      )
+    end
+
+    test "RbConfig paths are normalized in deprecation messages" do
+      paths = RbConfig::CONFIG.values_at("prefix", "sitelibdir", "rubylibdir").compact
+      assert_normalizes(
+        from: paths.map.with_index { |path, index| "#{path}/file-#{index}" }.join("\n"),
+        to: Array.new(paths.length) { |index| "<RUBY_INTERNALS>/file-#{index}" }.join("\n"),
+      )
+    end
+
+    private
+
+    def assert_normalizes(from:, to:)
+      Configuration.warnings_treated_as_deprecation = [/test deprecation/]
+      error = assert_raises(Behaviors::DeprecationIntroduced) do
+        warn("test deprecation: #{from}.")
+        trigger_deprecation_toolkit_behavior
+      end
+      assert_includes(error.message, to)
+    end
   end
 end

--- a/test/deprecation_toolkit/warning_test.rb
+++ b/test/deprecation_toolkit/warning_test.rb
@@ -181,6 +181,11 @@ module DeprecationToolkit
 
     test "Gem paths are normalized in deprecation messages" do
       paths = Gem.path
+      puts
+      puts
+      pp paths # TODO: Remove this (debugging CI)
+      puts
+      puts
       assert_normalizes(
         from: paths.map.with_index { |path, index| "#{path}/file-#{index}" }.join("\n"),
         to: Array.new(paths.length) { |index| "<GEM_PATH>/file-#{index}" }.join("\n"),

--- a/test/deprecation_toolkit/warning_test.rb
+++ b/test/deprecation_toolkit/warning_test.rb
@@ -183,6 +183,8 @@ module DeprecationToolkit
       paths = Gem.path
       puts
       puts
+      pp Configuration.message_normalizers
+      puts
       pp paths # TODO: Remove this (debugging CI)
       puts
       puts


### PR DESCRIPTION
## Summary

This (tentatively) adds support for registering deprecation message normalizers, and provides built in normalization of paths by looking for the following strings:

- appearances of `Dir.pwd`, which are replaced with `#{Dir.pwd}`
- appearances of any of `Gem.path`'s paths, which are replaced with `#{Gem.path[index]}`, where `index` is the index of the path in the `Gem.path` array

Replacements are made to look like interpolation, so it is clear what they represent.

This should resolve #48.

## ⚠️ Before Merging
- [ ] Validate approach
  - Should normalizers be expected to mutate the message (to avoid duplicate string allocations), or is it clearer if they return the normalized message (at the cost of creating duplicate objects)?
- [x] **Write tests**
- [ ] Consider other safe built in replacements that may have been missed.
  - What happens if a gem is sourced from somewhere non standard? e.g. GitHub? Path?
- [ ] Document new config in `README.md`
- [ ] Update `CHANGELOG.md`