### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fixing all deprecations at once might be tough depending on the size of your app
 
 ## How it works
 
-The Deprecation Toolkit gem works by using a [shitlist approach](https://confreaks.tv/videos/reddotrubyconf2017-shitlist-driven-development-and-other-tricks-for-working-on-large-codebases).
+The Deprecation Toolkit gem works by using a [shitlist approach](https://www.youtube.com/watch?v=20pj_ajDBOg).
 First, the gem records all existing deprecations into `.yml` files. When running a test that have non-recorded deprecations after the initial recording, Deprecation Toolkit triggers a behavior of your choice (by default it raises an error).
 
 ## Recording Deprecations


### PR DESCRIPTION
The link to https://confreaks.tv/videos/reddotrubyconf2017-shitlist-driven-development-and-other-tricks-for-working-on-large-codebases is broken, I found the video with the same title on YouTube - https://www.youtube.com/watch?v=20pj_ajDBOg.

<img width="616" alt="Screenshot 2022-03-31 at 19 54 52" src="https://user-images.githubusercontent.com/8367033/161098281-b0015ee9-735e-46d8-a501-4fda2619b565.png">
