### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
 
     - name: RuboCop
       run: bundle exec rubocop
+      if: ${{ matrix.ruby != '2.6' }}
 
     - name: Tests
       run: bundle exec rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,23 +7,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.3)
+    activesupport (7.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.15.0)
-    parallel (1.21.0)
-    parser (3.1.1.0)
+    json (2.6.2)
+    minitest (5.16.2)
+    parallel (1.22.1)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.2.1)
+    regexp_parser (2.5.0)
     rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
@@ -34,27 +35,28 @@ GEM
     rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-mocks (3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    rubocop (1.25.1)
+    rubocop (1.32.0)
+      json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.15.1, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.19.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.16.0)
+    rubocop-ast (1.19.1)
       parser (>= 3.1.1.0)
-    rubocop-shopify (2.5.0)
-      rubocop (~> 1.25)
+    rubocop-shopify (2.8.0)
+      rubocop (~> 1.31)
     ruby-progressbar (1.11.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.1.0)
+    unicode-display_width (2.2.0)
 
 PLATFORMS
   ruby
@@ -68,4 +70,4 @@ DEPENDENCIES
   rubocop-shopify
 
 BUNDLED WITH
-   2.2.22
+   2.3.18

--- a/test/deprecation_toolkit/warning_test.rb
+++ b/test/deprecation_toolkit/warning_test.rb
@@ -60,7 +60,9 @@ module DeprecationToolkit
 
     test "warn works as usual when no warnings are treated as deprecation" do
       assert_nothing_raised do
-        warn "Test warn works correctly"
+        capture_io do
+          warn "Test warn works correctly"
+        end
       end
     end
 


### PR DESCRIPTION
In order to ship #71, fixing CI.

Decided to skip Rubocop under 2.6 since it basically required dropping support for Ruby 2.6, and we just did a major version bump to drop support for 2.5.

BTW I'm not sure we should do a major bump each time we drop support for an old ruby, because that means one major a year for no good reason 🤔 