### PR TITLE
Use test case location to record deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         gemfile: [gemfiles/activesupport_5.2.gemfile, gemfiles/activesupport_6.0.gemfile, gemfiles/activesupport_6.1.gemfile, gemfiles/activesupport_7.0.gemfile, gemfiles/activesupport_edge.gemfile]
-        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         exclude:
         # Active Support requires Ruby >= 2.7 as of 7.0
         - gemfile: "gemfiles/activesupport_7.0.gemfile"
@@ -43,7 +43,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.1"
+        ruby-version: "3.2"
         bundler-cache: true
 
     - name: RuboCop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,4 +68,4 @@ DEPENDENCIES
   rubocop-shopify
 
 BUNDLED WITH
-   2.2.22
+   2.4.4

--- a/deprecation_toolkit.gemspec
+++ b/deprecation_toolkit.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.files = %x(git ls-files -z).split("\x0").reject do |f|
     f.match(%r{^(test)/})

--- a/lib/deprecation_toolkit/read_write_helper.rb
+++ b/lib/deprecation_toolkit/read_write_helper.rb
@@ -58,7 +58,7 @@ module DeprecationToolkit
     end
 
     def test_location(test)
-      test.method(test_name(test)).source_location[0]
+      Kernel.const_source_location(test.class.name)[0]
     rescue NameError
       "unknown"
     end


### PR DESCRIPTION
When recording deprecations, a test case may have methods that are defined in other modules (eg. shared tests). When passing the test location to the proc deprecation_path, use the test case location instead to infer shred tests should be deprecated on the host test case.