### PR TITLE
Show deprecations without stacktrace

### DIFF
--- a/lib/deprecation_toolkit/behaviors/raise.rb
+++ b/lib/deprecation_toolkit/behaviors/raise.rb
@@ -77,9 +77,9 @@ module DeprecationToolkit
           #{record_message}
 
           ===== Expected
-          #{recorded_deprecations.deprecations.join("\n")}
+          #{recorded_deprecations.deprecations_without_stacktrace.join("\n")}
           ===== Actual
-          #{current_deprecations.deprecations.join("\n")}
+          #{current_deprecations.deprecations_without_stacktrace.join("\n")}
         EOM
 
         super(message)

--- a/test/deprecation_toolkit/behaviors/raise_test.rb
+++ b/test/deprecation_toolkit/behaviors/raise_test.rb
@@ -15,26 +15,54 @@ module DeprecationToolkit
       end
 
       test ".trigger raises an DeprecationIntroduced error when deprecations are introduced" do
-        @expected_exception = DeprecationIntroduced
+        @expected_exception_class = DeprecationIntroduced
+        @expected_exception_message =
+          /DEPRECATION\ WARNING\:\ Foo\ \(called\ from\ .*\nDEPRECATION\ WARNING\:\ Bar\ \(called from\ .*/
 
         ActiveSupport::Deprecation.warn("Foo")
         ActiveSupport::Deprecation.warn("Bar")
       end
 
       test ".trigger raises a DeprecationRemoved error when deprecations are removed" do
-        @expected_exception = DeprecationRemoved
+        @expected_exception_class = DeprecationRemoved
+        @expected_exception_message = <<~EOM
+          You have removed deprecations from the codebase. Thanks for being an awesome person.
+          The recorded deprecations needs to be updated to reflect your changes.
+          You can re-record deprecations by adding the `--record-deprecations` flag when running your tests.
+
+          DEPRECATION WARNING: Bar
+        EOM
 
         ActiveSupport::Deprecation.warn("Foo")
       end
 
       test ".trigger raises a DeprecationRemoved when less deprecations than expected are triggerd and mismatches" do
-        @expected_exception = DeprecationRemoved
+        @expected_exception_class = DeprecationRemoved
+        @expected_exception_message = <<~EOM
+          You have removed deprecations from the codebase. Thanks for being an awesome person.
+          The recorded deprecations needs to be updated to reflect your changes.
+          You can re-record deprecations by adding the `--record-deprecations` flag when running your tests.
+
+          DEPRECATION WARNING: A
+          DEPRECATION WARNING: B
+        EOM
 
         ActiveSupport::Deprecation.warn("C")
       end
 
       test ".trigger raises a DeprecationMismatch when same number of deprecations are triggered with mismatches" do
-        @expected_exception = DeprecationMismatch
+        @expected_exception_class = DeprecationMismatch
+        @expected_exception_message = @expected_exception_message_template = <<~EOM
+          The recorded deprecations for this test doesn't match the one that got triggered.
+          Fix or record the new deprecations to discard this error.
+
+          You can re-record deprecations by adding the `--record-deprecations` flag when running your tests.
+
+          ===== Expected
+          DEPRECATION WARNING: C
+          ===== Actual
+          DEPRECATION WARNING: A
+        EOM
 
         ActiveSupport::Deprecation.warn("A")
       end
@@ -91,9 +119,15 @@ module DeprecationToolkit
 
       def trigger_deprecation_toolkit_behavior
         super
-        flunk if defined?(@expected_exception)
+        flunk if defined?(@expected_exception_class)
       rescue DeprecationIntroduced, DeprecationRemoved, DeprecationMismatch => e
-        assert_equal(@expected_exception, e.class, e.message)
+        assert_equal(@expected_exception_class, e.class)
+        case @expected_exception_message
+        when String
+          assert_equal(@expected_exception_message, e.message)
+        when Regexp
+          assert_match(@expected_exception_message, e.message)
+        end
       end
     end
   end

--- a/test/deprecations/deprecation_toolkit/behaviors/raise_test.yml
+++ b/test/deprecations/deprecation_toolkit/behaviors/raise_test.yml
@@ -6,9 +6,9 @@ test_.trigger_does_not_raise_when_deprecations_are_triggered_but_were_already_re
 - 'DEPRECATION WARNING: Foo'
 - 'DEPRECATION WARNING: Bar'
 test_.trigger_raises_a_DeprecationRemoved_when_less_deprecations_than_expected_are_triggerd_and_mismatches:
-- 'DEPRECATION_WARNING: A'
-- 'DEPRECATION_WARNING: B'
+- 'DEPRECATION WARNING: A'
+- 'DEPRECATION WARNING: B'
 test_.trigger_raises_a_DeprecationMismatch_when_same_number_of_deprecations_are_triggered_with_mismatches:
-- 'DEPRECATION_WARNING: C'
+- 'DEPRECATION WARNING: C'
 test_.trigger_does_not_raise_when_test_is_flaky:
   - flaky: true


### PR DESCRIPTION
See: https://discourse.shopify.io/t/mistmatched-deprecations-between-spin-and-buildkite/35884

Output is confusing right now because although the diff is between the deprecation _without_ the stacktrace, the message shows it _with_ the stacktrace.