### PR TITLE
Prepare for 2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+## 2.0.2 (2023-02-08)
+
+* [#78](https://github.com/Shopify/deprecation_toolkit/pull/78): Show deprecations without stacktrace. (@shioyama)
+
 ## 2.0.1 (2022-11-18)
 
 * [#74](https://github.com/Shopify/deprecation_toolkit/pull/74): Add support for `Rails.application.deprecators`. (@gmcgibbon)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deprecation_toolkit (2.0.1)
+    deprecation_toolkit (2.0.2)
       activesupport (>= 5.2)
 
 GEM

--- a/lib/deprecation_toolkit/version.rb
+++ b/lib/deprecation_toolkit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeprecationToolkit
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end


### PR DESCRIPTION
Releases https://github.com/Shopify/deprecation_toolkit/pull/78