### PR TITLE
Filter out stack trace from Gem::Deprecate deprecation messages

### DIFF
--- a/lib/deprecation_toolkit/collector.rb
+++ b/lib/deprecation_toolkit/collector.rb
@@ -35,11 +35,9 @@ module DeprecationToolkit
 
     def deprecations_without_stacktrace
       deprecations.map do |deprecation|
-        if ActiveSupport.gem_version.to_s < "5.0"
-          deprecation.sub(/\W\s\(called from .*\)$/, "")
-        else
-          deprecation.sub(/ \(called from .*\)$/, "")
-        end
+        deprecation
+          .sub(*active_support_deprecation_sub_params)
+          .sub(*gem_deprecate_sub_params)
       end
     end
 
@@ -62,6 +60,20 @@ module DeprecationToolkit
 
     def flaky?
       size == 1 && deprecations.first["flaky"] == true
+    end
+
+    private
+
+    def active_support_deprecation_sub_params
+      if ActiveSupport.gem_version.to_s < "5.0"
+        [/\W\s\(called from .*\)$/, ""]
+      else
+        [/ \(called from .*\)$/, ""]
+      end
+    end
+
+    def gem_deprecate_sub_params
+      [/NOTE: (.*is deprecated.*)\n.* called from.*:\d+\.\n/, "\\1"]
     end
   end
 end

--- a/test/deprecation_toolkit/behaviors/record_test.rb
+++ b/test/deprecation_toolkit/behaviors/record_test.rb
@@ -98,6 +98,7 @@ module DeprecationToolkit
         assert_match(/.*#example is deprecated; use new_example instead\./, recorded_deprecation)
         refute_match(/called from/, recorded_deprecation)
 
+      ensure
         Configuration.warnings_treated_as_deprecation = previous_warnings_treated_as_deprecation
       end
 

--- a/test/deprecation_toolkit/behaviors/record_test.rb
+++ b/test/deprecation_toolkit/behaviors/record_test.rb
@@ -80,15 +80,39 @@ module DeprecationToolkit
         end
       end
 
+      test ".trigger records deprecations without stack trace even for Gem::Deprecate" do
+        previous_warnings_treated_as_deprecation = Configuration.warnings_treated_as_deprecation
+        Configuration.warnings_treated_as_deprecation = [/#example is deprecated/]
+
+        # produce a Gem::Deprecate warning
+        dummy = Class.new do
+          extend Gem::Deprecate
+          def example; end
+          deprecate :example, :new_example, 2019, 1
+        end
+        dummy.new.example
+        trigger_deprecation_toolkit_behavior
+
+        recorded_deprecation = recorded_deprecations.first
+
+        assert_match(/.*#example is deprecated; use new_example instead\./, recorded_deprecation)
+        refute_match(/called from/, recorded_deprecation)
+
+        Configuration.warnings_treated_as_deprecation = previous_warnings_treated_as_deprecation
+      end
+
       private
 
       def assert_deprecations_recorded(*deprecation_triggered, to: @deprecation_path)
         yield
 
-        recorded = YAML.load_file("#{to}/deprecation_toolkit/behaviors/record_test.yml").fetch(name)
         triggered = deprecation_triggered.map { |msg| "DEPRECATION WARNING: #{msg}" }
 
-        assert_equal(recorded, triggered)
+        assert_equal(recorded_deprecations(to: to), triggered)
+      end
+
+      def recorded_deprecations(to: @deprecation_path)
+        YAML.load_file("#{to}/deprecation_toolkit/behaviors/record_test.yml").fetch(name)
       end
     end
   end


### PR DESCRIPTION
## Context

### `Gem::Deprecate`

[`Gem::Deprecate`](https://ruby-doc.org/3.2.0/stdlibs/rubygems/Gem/Deprecate.html) is a Ruby module that

> Provides 3 methods for declaring when something is going away.

Similarly to `ActiveSupport::Deprecation`, it generates warning messages, but with a different format:

```rb
class Foo
  extend Gem::Deprecate
  def old_method; end
  deprecate :old_method, :new_method, 2019, 1
end

Foo.new.old_method

# Produces this warning:
# NOTE: Foo#old_method is deprecated; use new_method instead. It will be removed on or after 2019-01.
# Foo#old_method called from (irb):7.
```

### Removing stack traces

`deprecation_toolkit` strips out stack traces from deprecation warnings when recording them:

https://github.com/Shopify/deprecation_toolkit/blob/ee55e609e8b8f943d206b780e1a45d1347c40974/lib/deprecation_toolkit/behaviors/record.rb#L11

https://github.com/Shopify/deprecation_toolkit/blob/ee55e609e8b8f943d206b780e1a45d1347c40974/lib/deprecation_toolkit/collector.rb#L36-L44

There are multiple reasons, but one of them is that we don't want the tool to detect a deprecation mismatch if the file path or line number changes.

### "Generic" warnings get converted to `ActiveSupport::Deprecation` warnings

The gem patches the `warn` method to record generic warnings as deprecations:

https://github.com/Shopify/deprecation_toolkit/blob/ee55e609e8b8f943d206b780e1a45d1347c40974/lib/deprecation_toolkit/warning.rb#L53

## Problem

As a consequence of the above, `Gem::Deprecate` deprecations trigger a warning that includes the stack trace twice:

```
DEPRECATION WARNING: NOTE: Stripe::Account#save is deprecated; use update instead. It will be removed on or after 2022-11.
Stripe::Account#save called from path/to/file.rb:521.
 (called from update_stripe_account at path/to/file.rb:521)
```

And because `#deprecations_without_stacktrace`'s logic is based on `ActiveSupport::Deprecation`'s format, the gem only strips one stack trace, and keeps the other when recording deprecations:

```yml
# test/deprecations/my_test.yml
---
test_do_something:
- |
  DEPRECATION WARNING: NOTE: Stripe::Account#save is deprecated; use update instead. It will be removed on or after 2022-11.
  Stripe::Account#save called from path/to/file.rb:521.
```

This goes against the idea that we'd like to filter out file paths and line numbers from recorded deprecations.

## Solution

The solution I propose is just one more substitution based on a regular expression.
Just as we're currently stripping out the stack trace added by `ActiveSupport::Deprecation` using `String#sub` and a regular expression, I propose we add another call to `#sub` with a different regular expression.

As `Gem::Deprecate` ships with Ruby, it would make sense to me that `deprecation_toolkit` be able to handle such deprecations out of the box.

## Shortcomings

I'm not super happy with the idea of stacking yet another regex substitution on top of what we already have. I'd have prefered if the gem was able to recognize `Gem::Deprecate` warnings when they're generated, so that we're not [wrapping](https://github.com/Shopify/deprecation_toolkit/blob/ee55e609e8b8f943d206b780e1a45d1347c40974/lib/deprecation_toolkit/warning.rb#L53) them in `ActiveSupport::Deprecation`.

Now I think about it, I would even consider a refactor of the gem so that it does not have to depend on `active_support`: the gem could work the same based on `Gem::Deprecate`, and supporting `ActiveSupport::Deprecation` (or other types of deprecations) should be as simple as implementing a plug-in for them.
