### PR TITLE
Update sed parser to remove ANSI codes

### DIFF
--- a/lib/tasks/ci_recorder.rake
+++ b/lib/tasks/ci_recorder.rake
@@ -29,7 +29,7 @@ class CIRecorder
 
   def extract_deprecations_output(file)
     tmp_file = Tempfile.new
-    shell_command = "cat #{file} | sed -n -e 's/^.* \\[DeprecationToolkit\\] \\(.*\\)/\\1/p' > #{tmp_file.path}"
+    shell_command = "cat #{file} | sed 's,\\x1B\\[[0-9;]*[a-zA-Z],,g' | sed -n -e 's/^.* \\[DeprecationToolkit\\] \\(.*\\)/\\1/p' > #{tmp_file.path}"
 
     raise "Couldn't extract deprecations from output" unless system(shell_command)
 


### PR DESCRIPTION
Very simply this updates the `deprecation_toolkit:record_from_ci_output` Rake task to strip ANSI codes from the log file generated the `CIRecorder` behaviour.

Without this addition the logs would not match the existing sed command and we would get no results,