### PR TITLE
Fix deprecated calls to ActiveSupport::Deprecation.warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Whenever a deprecation matches one of the regex, it is ignored.
 ```ruby
 DeprecationToolkit::Configuration.allowed_deprecations = [/Hello World/]
 
-ActiveSupport::Deprecation.warn('Hello World') # ignored by Deprecation Toolkit
+ActiveSupport::Deprecation.new.warn('Hello World') # ignored by Deprecation Toolkit
 ```
 
 When passing procs, each proc will get passed the deprecation message and the callstack.
@@ -99,7 +99,7 @@ DeprecationToolkit::Configuration.allowed_deprecations = [
 ]
 
 def method_triggering_deprecation
-  ActiveSupport::Deprecation.warn('Foo') # Ignored by the the DeprecationToolkit
+  ActiveSupport::Deprecation.new.warn('Foo') # Ignored by the the DeprecationToolkit
 end
 ```
 

--- a/lib/deprecation_toolkit/warning.rb
+++ b/lib/deprecation_toolkit/warning.rb
@@ -50,7 +50,7 @@ module DeprecationToolkit
       return unless str
 
       if DeprecationToolkit::Warning.deprecation_triggered?(str)
-        ActiveSupport::Deprecation.warn(str)
+        ActiveSupport::Deprecation.new.warn(str)
       else
         super
       end

--- a/spec/deprecation_toolkit/behaviors/disabled_spec.rb
+++ b/spec/deprecation_toolkit/behaviors/disabled_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
 
   it ".trigger noop any deprecations" do |example|
     expect do
-      ActiveSupport::Deprecation.warn("Foo")
-      ActiveSupport::Deprecation.warn("Bar")
+      ActiveSupport::Deprecation.new.warn("Foo")
+      ActiveSupport::Deprecation.new.warn("Bar")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end.not_to(raise_error)

--- a/spec/deprecation_toolkit/behaviors/raise_spec.rb
+++ b/spec/deprecation_toolkit/behaviors/raise_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
 
   it ".trigger raises an DeprecationIntroduced error when deprecations are introduced" do |example|
     expect do
-      ActiveSupport::Deprecation.warn("Foo")
-      ActiveSupport::Deprecation.warn("Bar")
+      ActiveSupport::Deprecation.new.warn("Foo")
+      ActiveSupport::Deprecation.new.warn("Bar")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end.to(raise_error(DeprecationToolkit::Behaviors::DeprecationIntroduced))
@@ -23,7 +23,7 @@ RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
 
   it ".trigger raises a DeprecationRemoved error when deprecations are removed" do |example|
     expect do
-      ActiveSupport::Deprecation.warn("Foo")
+      ActiveSupport::Deprecation.new.warn("Foo")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end.to(raise_error(DeprecationToolkit::Behaviors::DeprecationRemoved))
@@ -31,7 +31,7 @@ RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
 
   it ".trigger raises a DeprecationRemoved when mismatched and less than expected" do |example|
     expect do
-      ActiveSupport::Deprecation.warn("C")
+      ActiveSupport::Deprecation.new.warn("C")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end.to(raise_error(DeprecationToolkit::Behaviors::DeprecationRemoved))
@@ -39,7 +39,7 @@ RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
 
   it ".trigger raises a DeprecationMismatch when same number of deprecations are triggered with mismatches" do |example|
     expect do
-      ActiveSupport::Deprecation.warn("A")
+      ActiveSupport::Deprecation.new.warn("A")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end.to(raise_error(DeprecationToolkit::Behaviors::DeprecationMismatch))
@@ -47,8 +47,8 @@ RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
 
   it ".trigger does not raise when deprecations are triggered but were already recorded" do |example|
     expect do
-      ActiveSupport::Deprecation.warn("Foo")
-      ActiveSupport::Deprecation.warn("Bar")
+      ActiveSupport::Deprecation.new.warn("Foo")
+      ActiveSupport::Deprecation.new.warn("Bar")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end.not_to(raise_error)
@@ -59,7 +59,7 @@ RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
     DeprecationToolkit::Configuration.allowed_deprecations = [/John Doe/]
 
     begin
-      ActiveSupport::Deprecation.warn("John Doe")
+      ActiveSupport::Deprecation.new.warn("John Doe")
       expect do
         DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
       end.not_to(raise_error)
@@ -75,7 +75,7 @@ RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
       end
 
       def deprecation_callee
-        ActiveSupport::Deprecation.warn("John Doe")
+        ActiveSupport::Deprecation.new.warn("John Doe")
       end
     RUBY
 

--- a/spec/deprecation_toolkit/behaviors/record_spec.rb
+++ b/spec/deprecation_toolkit/behaviors/record_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe(DeprecationToolkit::Behaviors::Record) do
 
   it ".trigger should record deprecations" do |example|
     expect_deprecations_recorded("Foo", "Bar", example) do
-      ActiveSupport::Deprecation.warn("Foo")
-      ActiveSupport::Deprecation.warn("Bar")
+      ActiveSupport::Deprecation.new.warn("Foo")
+      ActiveSupport::Deprecation.new.warn("Bar")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end
@@ -29,14 +29,14 @@ RSpec.describe(DeprecationToolkit::Behaviors::Record) do
 
   it ".trigger re-record an existing deprecation file" do |example|
     expect_deprecations_recorded("Foo", "Bar", example) do
-      ActiveSupport::Deprecation.warn("Foo")
-      ActiveSupport::Deprecation.warn("Bar")
+      ActiveSupport::Deprecation.new.warn("Foo")
+      ActiveSupport::Deprecation.new.warn("Bar")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end
 
     expect_deprecations_recorded("Foo", example) do
-      ActiveSupport::Deprecation.warn("Foo")
+      ActiveSupport::Deprecation.new.warn("Foo")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end
@@ -44,7 +44,7 @@ RSpec.describe(DeprecationToolkit::Behaviors::Record) do
 
   it ".trigger removes the deprecation file when all deprecations were removed" do |example|
     expect_deprecations_recorded("Foo", example) do
-      ActiveSupport::Deprecation.warn("Foo")
+      ActiveSupport::Deprecation.new.warn("Foo")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end

--- a/test/deprecation_toolkit/behaviors/ci_record_helper_test.rb
+++ b/test/deprecation_toolkit/behaviors/ci_record_helper_test.rb
@@ -33,11 +33,11 @@ module DeprecationToolkit
           end
 
           def test_generate_deprecation
-            ActiveSupport::Deprecation.warn("Foo")
+            ActiveSupport::Deprecation.new.warn("Foo")
           end
 
           def test_generate_second_deprecation
-            ActiveSupport::Deprecation.warn("Bar")
+            ActiveSupport::Deprecation.new.warn("Bar")
           end
         end
 

--- a/test/deprecation_toolkit/behaviors/disabled_test.rb
+++ b/test/deprecation_toolkit/behaviors/disabled_test.rb
@@ -16,8 +16,8 @@ module DeprecationToolkit
 
       test ".trigger noop any deprecations" do
         assert_nothing_raised do
-          ActiveSupport::Deprecation.warn("Foo")
-          ActiveSupport::Deprecation.warn("Bar")
+          ActiveSupport::Deprecation.new.warn("Foo")
+          ActiveSupport::Deprecation.new.warn("Bar")
 
           trigger_deprecation_toolkit_behavior
         end

--- a/test/deprecation_toolkit/behaviors/raise_test.rb
+++ b/test/deprecation_toolkit/behaviors/raise_test.rb
@@ -19,8 +19,8 @@ module DeprecationToolkit
         @expected_exception_message =
           /DEPRECATION\ WARNING\:\ Foo\ \(called\ from\ .*\nDEPRECATION\ WARNING\:\ Bar\ \(called from\ .*/
 
-        ActiveSupport::Deprecation.warn("Foo")
-        ActiveSupport::Deprecation.warn("Bar")
+        ActiveSupport::Deprecation.new.warn("Foo")
+        ActiveSupport::Deprecation.new.warn("Bar")
       end
 
       test ".trigger raises a DeprecationRemoved error when deprecations are removed" do
@@ -33,7 +33,7 @@ module DeprecationToolkit
           DEPRECATION WARNING: Bar
         EOM
 
-        ActiveSupport::Deprecation.warn("Foo")
+        ActiveSupport::Deprecation.new.warn("Foo")
       end
 
       test ".trigger raises a DeprecationRemoved when less deprecations than expected are triggerd and mismatches" do
@@ -47,7 +47,7 @@ module DeprecationToolkit
           DEPRECATION WARNING: B
         EOM
 
-        ActiveSupport::Deprecation.warn("C")
+        ActiveSupport::Deprecation.new.warn("C")
       end
 
       test ".trigger raises a DeprecationMismatch when same number of deprecations are triggered with mismatches" do
@@ -64,13 +64,13 @@ module DeprecationToolkit
           DEPRECATION WARNING: A
         EOM
 
-        ActiveSupport::Deprecation.warn("A")
+        ActiveSupport::Deprecation.new.warn("A")
       end
 
       test ".trigger does not raise when deprecations are triggered but were already recorded" do
         assert_nothing_raised do
-          ActiveSupport::Deprecation.warn("Foo")
-          ActiveSupport::Deprecation.warn("Bar")
+          ActiveSupport::Deprecation.new.warn("Foo")
+          ActiveSupport::Deprecation.new.warn("Bar")
         end
       end
 
@@ -79,7 +79,7 @@ module DeprecationToolkit
         Configuration.allowed_deprecations = [/John Doe/]
 
         begin
-          ActiveSupport::Deprecation.warn("John Doe")
+          ActiveSupport::Deprecation.new.warn("John Doe")
           assert_nothing_raised { trigger_deprecation_toolkit_behavior }
         ensure
           Configuration.allowed_deprecations = @old_allowed_deprecations
@@ -93,7 +93,7 @@ module DeprecationToolkit
           end
 
           def deprecation_callee
-            ActiveSupport::Deprecation.warn("John Doe")
+            ActiveSupport::Deprecation.new.warn("John Doe")
           end
         RUBY
 
@@ -112,8 +112,8 @@ module DeprecationToolkit
 
       test ".trigger does not raise when test is flaky" do
         assert_nothing_raised do
-          ActiveSupport::Deprecation.warn("Foo")
-          ActiveSupport::Deprecation.warn("Bar")
+          ActiveSupport::Deprecation.new.warn("Foo")
+          ActiveSupport::Deprecation.new.warn("Bar")
         end
       end
 

--- a/test/deprecation_toolkit/behaviors/record_test.rb
+++ b/test/deprecation_toolkit/behaviors/record_test.rb
@@ -22,8 +22,8 @@ module DeprecationToolkit
 
       test ".trigger record deprecations" do
         assert_deprecations_recorded("Foo", "Bar") do
-          ActiveSupport::Deprecation.warn("Foo")
-          ActiveSupport::Deprecation.warn("Bar")
+          ActiveSupport::Deprecation.new.warn("Foo")
+          ActiveSupport::Deprecation.new.warn("Bar")
 
           trigger_deprecation_toolkit_behavior
         end
@@ -35,7 +35,7 @@ module DeprecationToolkit
         end
 
         assert_deprecations_recorded("Foo", to: "#{@deprecation_path}/prefix") do
-          ActiveSupport::Deprecation.warn("Foo")
+          ActiveSupport::Deprecation.new.warn("Foo")
 
           trigger_deprecation_toolkit_behavior
         end
@@ -55,14 +55,14 @@ module DeprecationToolkit
 
       test ".trigger re-record an existing deprecation file" do
         assert_deprecations_recorded("Foo", "Bar") do
-          ActiveSupport::Deprecation.warn("Foo")
-          ActiveSupport::Deprecation.warn("Bar")
+          ActiveSupport::Deprecation.new.warn("Foo")
+          ActiveSupport::Deprecation.new.warn("Bar")
 
           trigger_deprecation_toolkit_behavior
         end
 
         assert_deprecations_recorded("Foo") do
-          ActiveSupport::Deprecation.warn("Foo")
+          ActiveSupport::Deprecation.new.warn("Foo")
 
           trigger_deprecation_toolkit_behavior
         end
@@ -70,7 +70,7 @@ module DeprecationToolkit
 
       test ".trigger removes the deprecation file when all deprecations were removed" do
         assert_deprecations_recorded("Foo") do
-          ActiveSupport::Deprecation.warn("Foo")
+          ActiveSupport::Deprecation.new.warn("Foo")
 
           trigger_deprecation_toolkit_behavior
         end

--- a/test/minitest/deprecation_toolkit_plugin_test.rb
+++ b/test/minitest/deprecation_toolkit_plugin_test.rb
@@ -92,7 +92,7 @@ module Minitest
       end
 
       error = assert_raises(DeprecationToolkit::Behaviors::DeprecationIntroduced) do
-        ActiveSupport::Deprecation.warn("Deprecated!")
+        ActiveSupport::Deprecation.new.warn("Deprecated!")
         trigger_deprecation_toolkit_behavior
       end
 


### PR DESCRIPTION
See https://github.com/rails/rails/pull/47354

Fixes https://github.com/Shopify/deprecation_toolkit/issues/88.