### PR TITLE
Require missing Active Support core_ext for squish

### DIFF
--- a/lib/deprecation_toolkit/read_write_helper.rb
+++ b/lib/deprecation_toolkit/read_write_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/string/inflections"
+require "active_support/core_ext/string/filters"
 require "bundler"
 require "yaml"
 


### PR DESCRIPTION
While testing a minimal repro for #84, I got an exception when calling `squish`. We were missing the necessary `require` for it.