### PR TITLE
Remove more deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ jobs:
     name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }}
     strategy:
       matrix:
-        gemfile: [gemfiles/activesupport_5.2.gemfile, gemfiles/activesupport_6.0.gemfile, gemfiles/activesupport_6.1.gemfile, gemfiles/activesupport_7.0.gemfile, gemfiles/activesupport_edge.gemfile]
+        gemfile:
+          - Gemfile
+          - gemfiles/activesupport_5.2.gemfile
+          - gemfiles/activesupport_6.0.gemfile
+          - gemfiles/activesupport_6.1.gemfile
+          - gemfiles/activesupport_7.0.gemfile
+          - gemfiles/activesupport_edge.gemfile
         ruby: ["2.7", "3.0", "3.1", "3.2"]
         exclude:
         # Active Support requires Ruby >= 2.7 as of 7.0

--- a/gemfiles/activesupport_5.2.gemfile
+++ b/gemfiles/activesupport_5.2.gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-@activesupport_gem_requirement = "~> 5.2"
+@activesupport_gem_requirement = "~> 5.2.0"
 
 eval_gemfile "../Gemfile"

--- a/gemfiles/activesupport_6.0.gemfile
+++ b/gemfiles/activesupport_6.0.gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-@activesupport_gem_requirement = "~> 6.0"
+@activesupport_gem_requirement = "~> 6.0.0"
 
 eval_gemfile "../Gemfile"

--- a/gemfiles/activesupport_6.1.gemfile
+++ b/gemfiles/activesupport_6.1.gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-@activesupport_gem_requirement = "~> 6.1"
+@activesupport_gem_requirement = "~> 6.1.0"
 
 eval_gemfile "../Gemfile"

--- a/gemfiles/activesupport_7.0.gemfile
+++ b/gemfiles/activesupport_7.0.gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-@activesupport_gem_requirement = "~> 7.0"
+@activesupport_gem_requirement = "~> 7.0.0"
 
 eval_gemfile "../Gemfile"

--- a/lib/deprecation_toolkit/rspec_plugin.rb
+++ b/lib/deprecation_toolkit/rspec_plugin.rb
@@ -2,16 +2,22 @@
 
 module DeprecationToolkit
   module RSpecPlugin
+    extend self
+
     RSpec.configure do |config|
       config.before(:suite) do
-        case ENV["DEPRECATION_BEHAVIOR"]
-        when "r", "record", "record-deprecations"
-          DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Record
-        end
-
-        DeprecationToolkit.add_notify_behavior
-        DeprecationToolkit.attach_subscriber
+        RSpecPlugin.before_suite
       end
+    end
+
+    def before_suite
+      case ENV["DEPRECATION_BEHAVIOR"]
+      when "r", "record", "record-deprecations"
+        DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Record
+      end
+
+      DeprecationToolkit.add_notify_behavior
+      DeprecationToolkit.attach_subscriber
     end
   end
 end

--- a/spec/deprecation_toolkit/behaviors/disabled_spec.rb
+++ b/spec/deprecation_toolkit/behaviors/disabled_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
+  include TestDeprecator
+
   before do
     @previous_configuration = DeprecationToolkit::Configuration.behavior
     DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Disabled
@@ -14,8 +16,8 @@ RSpec.describe(DeprecationToolkit::Behaviors::Raise) do
 
   it ".trigger noop any deprecations" do |example|
     expect do
-      ActiveSupport::Deprecation.warn("Foo")
-      ActiveSupport::Deprecation.warn("Bar")
+      deprecator.warn("Foo")
+      deprecator.warn("Bar")
 
       DeprecationToolkit::TestTriggerer.trigger_deprecation_toolkit_behavior(example)
     end.not_to(raise_error)

--- a/spec/rspec/plugin_spec.rb
+++ b/spec/rspec/plugin_spec.rb
@@ -31,4 +31,18 @@ RSpec.describe(DeprecationToolkit::RSpecPlugin) do
       end
     end
   end
+
+  it "should add `notify` behavior to the deprecations behavior list with Rails.application.deprecators" do
+    behavior = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:notify]
+    deprecator = Rails.application.deprecators.each.first
+    expect(deprecator.behavior).to(include(behavior))
+  end
+
+  it "doesn't remove previous deprecation behaviors with Rails.application.deprecators" do
+    behavior = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:silence]
+    deprecator = Rails.application.deprecators.each.first
+
+    deprecator.behavior = behavior
+    expect(deprecator.behavior).to(include(behavior))
+  end
 end

--- a/spec/rspec/plugin_spec.rb
+++ b/spec/rspec/plugin_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe(DeprecationToolkit::RSpecPlugin) do
       with_rails_70_app do
         behavior = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:notify]
 
+        DeprecationToolkit::RSpecPlugin.before_suite
         expect(ActiveSupport::Deprecation.behavior).to(include(behavior))
       end
     end
@@ -24,6 +25,7 @@ RSpec.describe(DeprecationToolkit::RSpecPlugin) do
       with_rails_70_app do
         behavior = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:silence]
 
+        DeprecationToolkit::RSpecPlugin.before_suite
         ActiveSupport::Deprecation.behavior = behavior
         expect(ActiveSupport::Deprecation.behavior).to(include(behavior))
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "deprecation_toolkit"
 require "deprecation_toolkit/rspec_plugin"
 require "active_support/all"
 require_relative "../test/support/test_deprecator"
+require_relative "../test/support/fake_rails"
 
 DeprecationToolkit::Configuration.test_runner = :rspec
 DeprecationToolkit::Configuration.deprecation_path = "spec/deprecations"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,12 @@ require_relative "../test/support/fake_rails"
 DeprecationToolkit::Configuration.test_runner = :rspec
 DeprecationToolkit::Configuration.deprecation_path = "spec/deprecations"
 
+if ActiveSupport.respond_to?(:deprecator)
+  ActiveSupport.deprecator.behavior = :raise
+else
+  ActiveSupport::Deprecation.behavior = :raise
+end
+
 RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/test/deprecation_toolkit/behaviors/disabled_test.rb
+++ b/test/deprecation_toolkit/behaviors/disabled_test.rb
@@ -5,6 +5,8 @@ require "test_helper"
 module DeprecationToolkit
   module Behaviors
     class DisabledTest < ActiveSupport::TestCase
+      include TestDeprecator
+
       setup do
         @previous_configuration = Configuration.behavior
         Configuration.behavior = Disabled
@@ -16,8 +18,8 @@ module DeprecationToolkit
 
       test ".trigger noop any deprecations" do
         assert_nothing_raised do
-          ActiveSupport::Deprecation.warn("Foo")
-          ActiveSupport::Deprecation.warn("Bar")
+          deprecator.warn("Foo")
+          deprecator.warn("Bar")
 
           trigger_deprecation_toolkit_behavior
         end

--- a/test/minitest/deprecation_toolkit_plugin_test.rb
+++ b/test/minitest/deprecation_toolkit_plugin_test.rb
@@ -119,17 +119,21 @@ module Minitest
     end
 
     test ".plugin_deprecation_toolkit_init doesn't init plugin when outside bundler context" do
-      notify_behavior = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:notify]
-      old_bundle_gemfile = ENV["BUNDLE_GEMFILE"]
-      ENV.delete("BUNDLE_GEMFILE")
+      with_fake_application do
+        notify_behavior = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:notify]
+        old_bundle_gemfile = ENV["BUNDLE_GEMFILE"]
+        ENV.delete("BUNDLE_GEMFILE")
 
-      ActiveSupport::Deprecation.behavior.delete(notify_behavior)
-      Minitest.plugin_deprecation_toolkit_init({})
+        deprecator = Rails.application.deprecators.first
+        deprecator.behavior.delete(notify_behavior)
 
-      refute_includes(ActiveSupport::Deprecation.behavior, notify_behavior)
-    ensure
-      ENV["BUNDLE_GEMFILE"] = old_bundle_gemfile
-      ActiveSupport::Deprecation.behavior << notify_behavior
+        Minitest.plugin_deprecation_toolkit_init({})
+
+        refute_includes(deprecator.behavior, notify_behavior)
+      ensure
+        ENV["BUNDLE_GEMFILE"] = old_bundle_gemfile
+        deprecator.behavior << notify_behavior
+      end
     end
   end
 end

--- a/test/support/fake_rails.rb
+++ b/test/support/fake_rails.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# This is needed so that when we run the tests in this project, and the plugin is initialized by Minitest, we don't
+# cause a deprecation warning by calling `ActiveSupport::Deprecation.behavior` and `.behavior=`.
+module Rails
+  def self.application
+    Application
+  end
+
+  module Application
+    def self.deprecators
+      @deprecators ||= DeprecatorSet.new
+    end
+  end
+
+  class DeprecatorSet
+    def initialize
+      @deprecator = ActiveSupport::Deprecation.new
+      @deprecator.behavior = :raise
+    end
+
+    def each
+      return to_enum unless block_given?
+
+      yield @deprecator
+    end
+
+    def behavior=(behavior)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,28 +6,7 @@ require "deprecation_toolkit"
 require "minitest/autorun"
 require "active_support/all"
 require_relative "support/test_deprecator"
+require_relative "support/fake_rails"
 
 ActiveSupport::Deprecation.behavior = :silence
 ActiveSupport::TestCase.test_order = :random
-
-# This is needed so that when we run the tests in this project, and the plugin is initialized by Minitest, we don't
-# cause a deprecation warning by calling `ActiveSupport::Deprecation.behavior` and `.behavior=`.
-module Rails
-  def self.application
-    Application
-  end
-
-  module Application
-    def self.deprecators
-      DeprecatorSet
-    end
-  end
-
-  module DeprecatorSet
-    def self.each
-    end
-
-    def self.behavior=(behavior)
-    end
-  end
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,5 +8,9 @@ require "active_support/all"
 require_relative "support/test_deprecator"
 require_relative "support/fake_rails"
 
-ActiveSupport::Deprecation.behavior = :silence
+if ActiveSupport.respond_to?(:deprecator)
+  ActiveSupport.deprecator.behavior = :raise
+else
+  ActiveSupport::Deprecation.behavior = :raise
+end
 ActiveSupport::TestCase.test_order = :random


### PR DESCRIPTION
I forgot a few in #90, this removes them.

I also had to bring the new "fake Rails 7.1 app" setup so that we wouldn't call the deprecated behavior. And similarly kept the tests testing that behavior but only when not running Active Support >= 7.1.

We paired with @adrianna-chang-shopify on this. We had to extract the RSpec plugin setup so that we could call it and check its behavior, previously the plugin specs were not exercising anything, just asserting that the behavior had happened while booting the spec suite.

Also CI was mistakenly configured where it was testing 7.1 with `gemfiles/activesupport_7.0.gemfile` Gemfile. And we were not testing with `Gemfile` directly.
