### PR TITLE
Allow configuration of minitest file paths and file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main (unreleased)
 
+* [#95](https://github.com/Shopify/deprecation_toolkit/pull/95): Allow configuration of deprecation file paths and file names.
+
 ## 2.0.4 (2023-11-20)
 
 * [#90](https://github.com/Shopify/deprecation_toolkit/pull/90) & [#93](https://github.com/Shopify/deprecation_toolkit/pull/93): Stop using deprecated behavior from Active Support. (@etiennebarrie)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,31 @@ This setting accepts an array of regular expressions. To match on all warnings, 
 DeprecationToolkit::Configuration.warnings_treated_as_deprecation = [//]
 ```
 
+### 🔨 `#DeprecationToolkit::Configuration#deprecation_file_path_format`
+
+DeprecationToolkit allows you to choose the file path format for deprecation files.
+
+For Minitest, it defaults to using class name so the following code would correspond to `#{deprecation_path}/deprecation_toolkit/behaviors/raise_test.yml`
+
+```ruby
+module DeprecationToolkit
+  module Behaviors
+    class RaiseTest < ActiveSupport::TestCase
+    end
+  end
+end
+```
+
+For rspec if defaults to the file location with spec removed. `/spec/models/user_spec.rb` would correspond to `/models/user.yml`.
+
+If you have a specific use case you can configure this with a custom format using a proc. The proc is called with an instance of the test.
+
+```ruby
+Configuration.deprecation_file_path_format = -> (test) do
+  Kernel.const_source_location(test.class.name)[0].sub(%r{^./test/}, "").sub(/_test.rb$/, "")
+end
+```
+
 ## RSpec
 
 By default Deprecation Toolkit uses Minitest as its test runner. To use Deprecation Toolkit with RSpec you'll have to configure it.

--- a/lib/deprecation_toolkit/configuration.rb
+++ b/lib/deprecation_toolkit/configuration.rb
@@ -12,5 +12,14 @@ module DeprecationToolkit
     config_accessor(:deprecation_path) { "test/deprecations" }
     config_accessor(:test_runner) { :minitest }
     config_accessor(:warnings_treated_as_deprecation) { [] }
+    config_accessor(:deprecation_file_path_format) do
+      proc do |test|
+        if DeprecationToolkit::Configuration.test_runner == :rspec
+          test.example_group.file_path.sub(%r{^./spec/}, "").sub(/_spec.rb$/, "")
+        else
+          test.class.name.underscore
+        end
+      end
+    end
   end
 end

--- a/lib/deprecation_toolkit/read_write_helper.rb
+++ b/lib/deprecation_toolkit/read_write_helper.rb
@@ -48,17 +48,7 @@ module DeprecationToolkit
         Configuration.deprecation_path
       end
 
-      path =
-        if DeprecationToolkit::Configuration.test_runner == :rspec
-          test.example_group.file_path.sub(%r{^./spec/}, "").sub(/_spec.rb$/, "")
-        else
-          test_path = test_location(test)
-          if test_path == "unknown"
-            test.class.name.underscore
-          else
-            File.dirname(test.class.name.underscore) + "/" + File.basename(test_path, ".*")
-          end
-        end
+      path = Configuration.deprecation_file_path_format.call(test)
 
       Pathname(deprecation_folder).join("#{path}.yml")
     end

--- a/lib/deprecation_toolkit/read_write_helper.rb
+++ b/lib/deprecation_toolkit/read_write_helper.rb
@@ -52,7 +52,12 @@ module DeprecationToolkit
         if DeprecationToolkit::Configuration.test_runner == :rspec
           test.example_group.file_path.sub(%r{^./spec/}, "").sub(/_spec.rb$/, "")
         else
-          test.class.name.underscore
+          test_path = test_location(test)
+          if test_path == "unknown"
+            test.class.name.underscore
+          else
+            File.dirname(test.class.name.underscore) + "/" + File.basename(test_path, ".*")
+          end
         end
 
       Pathname(deprecation_folder).join("#{path}.yml")

--- a/test/deprecation_toolkit/behaviors/record_test.rb
+++ b/test/deprecation_toolkit/behaviors/record_test.rb
@@ -31,6 +31,23 @@ module DeprecationToolkit
         end
       end
 
+      class TestClass < RecordTest
+        test ".trigger record deprecations using correct filename in subclasses" do
+          assert_deprecations_recorded("Foo", "Bar") do
+            deprecator.warn("Foo")
+            deprecator.warn("Bar")
+
+            trigger_deprecation_toolkit_behavior
+          end
+        end
+
+        private
+
+        def recorded_deprecations(to: @deprecation_path)
+          YAML.load_file("#{to}/deprecation_toolkit/behaviors/record_test/record_test.yml").fetch(name)
+        end
+      end
+
       test ".trigger record deprecations for proc path" do
         Configuration.deprecation_path = proc do
           File.join(@deprecation_path, "prefix")


### PR DESCRIPTION
### Background

Currently, deprecation toolkit uses `class.name.underscore` to name the files where it stores the deprecations, which works well in most cases, but means that in the case of subclasses in test files (or typos), the actual files containing the deprecations are hard to find.

### The Change

This allows the user to configure the file path/name format for their setup. It would allow folks to use the full file paths if that's easier for them and customize in any way that suits while maintaining the current behaviour as the default.