### PR TITLE
Exclude ruby 2.7 and 3.0 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,10 @@ jobs:
           - gemfiles/activesupport_edge.gemfile
         ruby: ["2.7", "3.0", "3.1", "3.2"]
         exclude:
-        # Active Support requires Ruby >= 2.7 as of 7.0
-        - gemfile: "gemfiles/activesupport_7.0.gemfile"
-          ruby: "2.6"
-        - gemfile: "gemfiles/activesupport_edge.gemfile"
-          ruby: "2.6"
+          - gemfile: gemfiles/activesupport_edge.gemfile
+            ruby: "2.7"
+          - gemfile: gemfiles/activesupport_edge.gemfile
+            ruby: "3.0"
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:


### PR DESCRIPTION
With the minimum ruby version of 3.1 CI was failing for edge on ruby 2.7 and ruby 3.0. This PR excludes those from CI. Also removes an old exclude for a ruby version not in the matric