### PR TITLE
Fix `Warning.warn` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main (unreleased)
 
+* [#99](https://github.com/Shopify/deprecation_toolkit/pull/99): Fix `Warning.warn` hook to accept a category.
 * [#95](https://github.com/Shopify/deprecation_toolkit/pull/95): Allow configuration of deprecation file paths and file names.
 
 ## 2.0.4 (2023-11-20)

--- a/lib/deprecation_toolkit/warning.rb
+++ b/lib/deprecation_toolkit/warning.rb
@@ -52,7 +52,7 @@ end
 
 module DeprecationToolkit
   module WarningPatch
-    def warn(str)
+    def warn(str, *)
       str = DeprecationToolkit::Warning.handle_multipart(str)
       return unless str
 
@@ -62,6 +62,7 @@ module DeprecationToolkit
         super
       end
     end
+    ruby2_keywords :warn
   end
 end
 Warning.singleton_class.prepend(DeprecationToolkit::WarningPatch)


### PR DESCRIPTION
`warn` may accept a `category:` keyword argument.