### PR TITLE
Clarify that by default the gem_name is rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,14 @@ DEPRECATION_BEHAVIOR="record" bundle exec rspec path/to/file_spec.rb
 
 ## Usage without Rails
 
-Without Rails, you'll need to make sure your `ActiveSupport::Deprecation` instances use the [`:notify` behavior](https://api.rubyonrails.org/classes/ActiveSupport/Deprecation/Behavior.html#method-i-behavior-3D).
+Without Rails, you'll need to make sure your `ActiveSupport::Deprecation` instances use the [`:notify` behavior](https://api.rubyonrails.org/classes/ActiveSupport/Deprecation/Behavior.html#method-i-behavior-3D) and the `attach_to` is the name of the gem (or repository) like the following example: 
+
+```ruby
+DeprecationToolkit::Configuration.configure do |config|
+  config.attach_to = ["the_repository_name"]
+  config.behavior = :notify
+end
+```
 
 ## License
 


### PR DESCRIPTION
I am using this gem on a repository that isn't using Rails. I migrated from  `ActiveSupport::Deprecation.warn(...)` to `ActiveSupport::Deprecation.new.warn()` and it was not logging any deprecation call.

The reason is that, by default , [the gem attaches to :rails](https://github.com/Shopify/deprecation_toolkit/blob/953c26d48a75edcf844c97437f2596d414a7bebf/lib/deprecation_toolkit.rb#L37-L39). 

This PR clarifies in the README that if you're not using Rails then you should set `attach_to` correctly.