### PR TITLE
Allow deprecation toolkit to be attached to multiple gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 gem "bundler"
 gem "minitest"
+gem "minitest-bisect"
 gem "rake"
 gem "rspec"
 gem "rubocop-shopify"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,10 +34,17 @@ GEM
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
     minitest (5.25.5)
+    minitest-bisect (1.7.0)
+      minitest-server (~> 1.0)
+      path_expander (~> 1.1)
+    minitest-server (1.0.8)
+      drb (~> 2.0)
+      minitest (~> 5.16)
     parallel (1.24.0)
     parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
+    path_expander (1.1.3)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -85,6 +92,7 @@ DEPENDENCIES
   bundler
   deprecation_toolkit!
   minitest
+  minitest-bisect
   rake
   rspec
   rubocop-shopify

--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -16,6 +16,9 @@ module DeprecationToolkit
     autoload :Raise,                   "deprecation_toolkit/behaviors/raise"
     autoload :Record,                  "deprecation_toolkit/behaviors/record"
     autoload :CIRecordHelper,          "deprecation_toolkit/behaviors/ci_record_helper"
+    autoload :DeprecationIntroduced,   "deprecation_toolkit/behaviors/raise"
+    autoload :DeprecationRemoved,      "deprecation_toolkit/behaviors/raise"
+    autoload :DeprecationMismatch,     "deprecation_toolkit/behaviors/raise"
   end
 
   class << self

--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -35,8 +35,6 @@ module DeprecationToolkit
     end
 
     def attach_subscriber
-      return if DeprecationSubscriber.already_attached?
-
       Configuration.attach_to.each do |gem_name|
         DeprecationSubscriber.attach_to(gem_name)
       end

--- a/lib/deprecation_toolkit/deprecation_subscriber.rb
+++ b/lib/deprecation_toolkit/deprecation_subscriber.rb
@@ -5,8 +5,54 @@ require "active_support/subscriber"
 module DeprecationToolkit
   class DeprecationSubscriber < ActiveSupport::Subscriber
     class << self
-      def already_attached?
-        notifier != nil
+      def attach_to(gem_name, subscriber = new, notifier = ActiveSupport::Notifications, inherit_all: false)
+        return if already_attached_to?(gem_name)
+
+        super(gem_name, subscriber, notifier, inherit_all: inherit_all)
+      end
+
+      def detach_from(gem_name, notifier = ActiveSupport::Notifications)
+        @namespace  = gem_name
+        @subscriber = find_attached_subscriber(gem_name)
+        @notifier = notifier
+
+        return unless subscriber
+
+        subscribers.delete(subscriber)
+
+        # Remove event subscribers of all existing methods on the class.
+        fetch_public_methods(subscriber, true).each do |event|
+          remove_event_subscriber(event)
+        end
+
+        @notifier = nil unless any_subscribers_attached?
+      end
+
+      private
+
+      def already_attached_to?(gem_name)
+        subscribers.any? do |subscriber|
+          attached_subscriber?(subscriber, gem_name)
+        end
+      end
+
+      def any_subscribers_attached?
+        subscribers.any? do |subscriber|
+          subscriber.is_a?(self)
+        end
+      end
+
+      def find_attached_subscriber(gem_name)
+        subscribers.find do |attached_subscriber|
+          attached_subscriber?(attached_subscriber, gem_name)
+        end
+      end
+
+      def attached_subscriber?(subscriber, gem_name)
+        subscriber.is_a?(self) &&
+          subscriber.patterns.keys.any? do |pattern|
+            pattern.end_with?(".#{gem_name}")
+          end
       end
     end
 

--- a/lib/minitest/deprecation_toolkit_plugin.rb
+++ b/lib/minitest/deprecation_toolkit_plugin.rb
@@ -14,6 +14,10 @@ module Minitest
 
     require "deprecation_toolkit"
 
+    setup_deprecation_toolkit(options)
+  end
+
+  def setup_deprecation_toolkit(options)
     if options[:record_deprecations]
       DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Record
     end

--- a/test/deprecation_toolkit/deprecation_subscriber_test.rb
+++ b/test/deprecation_toolkit/deprecation_subscriber_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module DeprecationToolkit
+  class DeprecationSubscriberTest < ActiveSupport::TestCase
+    setup do
+      @previous_behavior = Configuration.behavior
+      @previous_allowed_deprecations = Configuration.allowed_deprecations
+      Configuration.behavior = Behaviors::Disabled
+      Configuration.allowed_deprecations = []
+      Collector.reset!
+    end
+
+    teardown do
+      Configuration.behavior = @previous_behavior
+      Configuration.allowed_deprecations = @previous_allowed_deprecations
+      DeprecationSubscriber.detach_from(:test_gem)
+      Collector.reset!
+    end
+
+    test ".attach_to attaches a subscriber to a gem" do
+      test_deprecator = ActiveSupport::Deprecation.new("next version", "test_gem")
+      test_deprecator.behavior = :notify
+
+      DeprecationSubscriber.attach_to(:test_gem)
+
+      test_deprecator.warn("Test deprecation message")
+
+      assert_equal 1, Collector.deprecations.size
+      assert_match(/^DEPRECATION WARNING: Test deprecation message/, Collector.deprecations.first)
+    end
+
+    test ".attach_to does not attach a subscriber if already attached" do
+      test_deprecator = ActiveSupport::Deprecation.new("next version", "test_gem")
+      test_deprecator.behavior = :notify
+
+      DeprecationSubscriber.attach_to(:test_gem)
+      DeprecationSubscriber.attach_to(:test_gem)
+
+      test_deprecator.warn("Test deprecation message")
+
+      assert_equal 1, Collector.deprecations.size
+    end
+
+    test ".detach_from removes a subscriber" do
+      test_deprecator = ActiveSupport::Deprecation.new("next version", "test_gem")
+      test_deprecator.behavior = :notify
+
+      DeprecationSubscriber.attach_to(:test_gem)
+
+      DeprecationSubscriber.detach_from(:test_gem)
+
+      test_deprecator.warn("Test deprecation message")
+
+      assert_equal 0, Collector.deprecations.size
+    end
+
+    test "#deprecation does not collect allowed deprecations" do
+      Configuration.allowed_deprecations = [/Test deprecation message/]
+
+      test_deprecator = ActiveSupport::Deprecation.new("next version", "test_gem")
+      test_deprecator.behavior = :notify
+
+      DeprecationSubscriber.attach_to(:test_gem)
+
+      test_deprecator.warn("Test deprecation message")
+
+      assert_equal 0, Collector.deprecations.size
+    end
+
+    test "#deprecation does not collect deprecations allowed by a proc" do
+      Configuration.allowed_deprecations = [
+        ->(message, _stack) { message.include?("Test deprecation message") },
+      ]
+
+      test_deprecator = ActiveSupport::Deprecation.new("next version", "test_gem")
+      test_deprecator.behavior = :notify
+
+      DeprecationSubscriber.attach_to(:test_gem)
+
+      test_deprecator.warn("Test deprecation message")
+
+      assert_equal 0, Collector.deprecations.size
+    end
+  end
+end

--- a/test/deprecation_toolkit/deprecation_toolkit_test.rb
+++ b/test/deprecation_toolkit/deprecation_toolkit_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module DeprecationToolkit
+  class DeprecationToolkitTest < ActiveSupport::TestCase
+    setup do
+      @previous_attach_to = Configuration.attach_to
+      @previous_behavior = Configuration.behavior
+      Configuration.behavior = Behaviors::Disabled
+    end
+
+    teardown do
+      Configuration.attach_to = @previous_attach_to
+      Configuration.behavior = @previous_behavior
+      # Clean up any subscribers that might have been attached during tests
+      DeprecationSubscriber.detach_from(:test_gem)
+      DeprecationSubscriber.detach_from(:another_gem)
+      Collector.reset!
+    end
+
+    test ".attach_subscriber attaches to each gem specified in Configuration.attach_to" do
+      Configuration.attach_to = [:test_gem]
+
+      DeprecationToolkit.attach_subscriber
+
+      test_deprecator = ActiveSupport::Deprecation.new("next version", "test_gem")
+      test_deprecator.behavior = :notify
+
+      test_deprecator.warn("Test deprecation message")
+
+      assert_equal 1, Collector.deprecations.size
+      assert_match(/^DEPRECATION WARNING: Test deprecation message/, Collector.deprecations.first)
+    end
+
+    test ".attach_subscriber does nothing when Configuration.attach_to is empty" do
+      Configuration.attach_to = []
+
+      DeprecationToolkit.attach_subscriber
+
+      test_deprecator = ActiveSupport::Deprecation.new("next version", "test_gem")
+      test_deprecator.behavior = :notify
+
+      test_deprecator.warn("Test deprecation message")
+
+      assert_equal 0, Collector.deprecations.size
+    end
+
+    test ".attach_subscriber adds new gems without duplicating existing subscribers" do
+      Configuration.attach_to = [:test_gem]
+      DeprecationToolkit.attach_subscriber
+
+      test_deprecator = ActiveSupport::Deprecation.new("next version", "test_gem")
+      test_deprecator.behavior = :notify
+
+      test_deprecator.warn("Test deprecation message 1")
+
+      assert_equal 1, Collector.deprecations.size
+
+      Configuration.attach_to = [:test_gem, :another_gem]
+
+      DeprecationToolkit.attach_subscriber
+
+      Collector.reset!
+
+      another_deprecator = ActiveSupport::Deprecation.new("next version", "another_gem")
+      another_deprecator.behavior = :notify
+
+      another_deprecator.warn("Test deprecation message 2")
+
+      assert_equal 1, Collector.deprecations.size
+      assert_match(/^DEPRECATION WARNING: Test deprecation message 2/, Collector.deprecations.first)
+
+      Collector.reset!
+      test_deprecator.warn("Test deprecation message 3")
+      assert_equal 1, Collector.deprecations.size
+      assert_match(/^DEPRECATION WARNING: Test deprecation message 3/, Collector.deprecations.first)
+    end
+  end
+end

--- a/test/minitest/deprecation_toolkit_plugin_test.rb
+++ b/test/minitest/deprecation_toolkit_plugin_test.rb
@@ -32,6 +32,10 @@ module Minitest
       end
     end
 
+    teardown do
+      DeprecationToolkit::DeprecationSubscriber.detach_from(:rails)
+    end
+
     test ".plugin_deprecation_toolkit_options when running test with the `-r` flag" do
       option_parser = OptionParser.new
       options = {}
@@ -125,7 +129,9 @@ module Minitest
         trigger_deprecation_toolkit_behavior
       end
 
-      assert_equal 1, error.message.scan("DEPRECATION WARNING: Deprecated!").count
+      assert_equal(1, error.message.scan("DEPRECATION WARNING: Deprecated!").count)
+    ensure
+      DeprecationToolkit::DeprecationSubscriber.detach_from(:my_gem)
     end
 
     test ".plugin_deprecation_toolkit_init doesn't init plugin when outside bundler context" do


### PR DESCRIPTION
Before, when the minitest plugin was used, the `attach_to` method of the `DeprecationSubscriber` class was called first only with the default set of gems to subscribe, which was `[:rails]`.

If the app added more gems to the `Configuration.attach_to` array, the `attach_subscriber` method was called again with the new gems, but this time, the `already_attached_to?` would return `true` since there was already a notifier in the subscriber.

We should check the subscribers instead and make sure we don't attach again to the same namespace.