### PR TITLE
fix: do not suppress allowed warn messages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main (unreleased)
 
+* [#140](https://github.com/Shopify/deprecation_toolkit/pull/140) Fixed a bug where `warnings_treated_as_deprecation` would suppress warnings even if they were explicitly allowed.
+
 ## 2.2.4 (2025-08-08)
 
 * [#136](https://github.com/Shopify/deprecation_toolkit/pull/136) Stable write logic.

--- a/lib/deprecation_toolkit.rb
+++ b/lib/deprecation_toolkit.rb
@@ -10,6 +10,7 @@ module DeprecationToolkit
   autoload :Collector,                 "deprecation_toolkit/collector"
   autoload :ReadWriteHelper,           "deprecation_toolkit/read_write_helper"
   autoload :TestTriggerer,             "deprecation_toolkit/test_triggerer"
+  autoload :DeprecationAllowed,        "deprecation_toolkit/deprecation_allowed"
 
   module Behaviors
     autoload :Disabled,                "deprecation_toolkit/behaviors/disabled"

--- a/lib/deprecation_toolkit/deprecation_allowed.rb
+++ b/lib/deprecation_toolkit/deprecation_allowed.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DeprecationToolkit
+  class DeprecationAllowed
+    class << self
+      # Checks if a deprecation is allowed by the configured rules.
+      #
+      # A rule can be a `Regexp` to match the deprecation message, or a callable object that will receive the
+      # message and the callstack to perform a more advanced check.
+      #
+      # @param payload [Hash] The payload from the deprecation event.
+      # @option payload [String] :message The deprecation message.
+      # @option payload [Array<String>] :callstack The callstack for the deprecation.
+      # @return [Boolean] `true` if the deprecation is allowed, `false` otherwise.
+      def call(payload)
+        Configuration.allowed_deprecations.any? do |rule|
+          if rule.is_a?(Regexp)
+            rule.match?(payload[:message])
+          else
+            rule.call(payload[:message], payload[:callstack])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/deprecation_toolkit/deprecation_subscriber.rb
+++ b/lib/deprecation_toolkit/deprecation_subscriber.rb
@@ -59,19 +59,7 @@ module DeprecationToolkit
     def deprecation(event)
       message = event.payload[:message]
 
-      Collector.collect(message) unless deprecation_allowed?(event.payload)
-    end
-
-    private
-
-    def deprecation_allowed?(payload)
-      Configuration.allowed_deprecations.any? do |rule|
-        if rule.is_a?(Regexp)
-          rule.match?(payload[:message])
-        else
-          rule.call(payload[:message], payload[:callstack])
-        end
-      end
+      Collector.collect(message) unless DeprecationToolkit::DeprecationAllowed.call(event.payload)
     end
   end
 end


### PR DESCRIPTION
Using `warnings_treated_as_deprecation` caused warn messages to be suppressed even when explicitly allowed.
This happened because the deprecator neither logs those messages nor saves them in the deprecation file.

### How to test

1. Remove the line added to the `lib/deprecation_toolkit/warning.rb#deprecation_triggered?` method.
2. Run the tests and confirm that the new test fails.