### PR TITLE
Add config for deprecation_test_name_normalize to help with thrashing

### DIFF
--- a/lib/deprecation_toolkit/configuration.rb
+++ b/lib/deprecation_toolkit/configuration.rb
@@ -29,6 +29,11 @@ module DeprecationToolkit
     end
     singleton_class.attr_accessor(:deprecation_file_path_format)
 
+    @deprecation_test_name_normalize = proc do |test_name|
+      test_name
+    end
+    singleton_class.attr_accessor(:deprecation_test_name_normalize)
+
     class << self
       def configure
         yield self

--- a/lib/deprecation_toolkit/read_write_helper.rb
+++ b/lib/deprecation_toolkit/read_write_helper.rb
@@ -9,7 +9,22 @@ module DeprecationToolkit
   module ReadWriteHelper
     def read(test)
       deprecation_file = Bundler.root.join(recorded_deprecations_path(test))
-      YAML.load(deprecation_file.read).fetch(test_name(test), [])
+      data = YAML.load(deprecation_file.read)
+      name = test_name(test)
+
+      # Fast path: exact match
+      return data[name] if data.key?(name)
+
+      # Fallback: match by normalized name (handles tag addition/removal)
+      normalized_name = normalized_test_name(name)
+      return data[normalized_name] if data.key?(normalized_name)
+
+      # Fallback: iterate over all normalized keys
+      data.each do |key, deprecations|
+        return deprecations if normalized_test_name(key) == normalized_name
+      end
+
+      []
     rescue Errno::ENOENT
       []
     end
@@ -19,6 +34,10 @@ module DeprecationToolkit
       updated_deprecations = original_deprecations.dup
 
       deprecations_to_record.each do |test, deprecation_to_record|
+        # Remove any stale key that normalizes to the same name
+        normalized = normalized_test_name(test)
+        updated_deprecations.delete_if { |key, _| key != test && normalized_test_name(key) == normalized }
+
         if deprecation_to_record.any?
           updated_deprecations[test] = deprecation_to_record
         else
@@ -62,6 +81,10 @@ module DeprecationToolkit
       else
         test.name
       end
+    end
+
+    def normalized_test_name(name)
+      DeprecationToolkit::Configuration.deprecation_test_name_normalize.call(name)
     end
   end
 end

--- a/test/deprecation_toolkit/configuration_test.rb
+++ b/test/deprecation_toolkit/configuration_test.rb
@@ -24,6 +24,10 @@ module DeprecationToolkit
       assert_equal :minitest, Configuration.test_runner
     end
 
+    test ".deprecation_test_name_normalize is by default an identity proc" do
+      assert_equal "test_foo", Configuration.deprecation_test_name_normalize.call("test_foo")
+    end
+
     test ".configure allows setting configuration options" do
       previous_behavior = Configuration.behavior
 

--- a/test/deprecation_toolkit/read_write_helper_test.rb
+++ b/test/deprecation_toolkit/read_write_helper_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+module DeprecationToolkit
+  class ReadWriteHelperTest < ActiveSupport::TestCase
+    include TestDeprecator
+
+    Helper = Object.new.extend(ReadWriteHelper)
+
+    setup do
+      @previous_deprecation_path = Configuration.deprecation_path
+      @previous_behavior = Configuration.behavior
+      @previous_normalize = Configuration.deprecation_test_name_normalize
+      @deprecation_path = Dir.mktmpdir
+      Configuration.behavior = Behaviors::Record
+      Configuration.deprecation_path = @deprecation_path
+    end
+
+    teardown do
+      Configuration.behavior = @previous_behavior
+      Configuration.deprecation_path = @previous_deprecation_path
+      Configuration.deprecation_test_name_normalize = @previous_normalize
+      FileUtils.rm_rf(@deprecation_path)
+    end
+
+    test "read matches by exact name" do
+      write_deprecation_file("test_exact_match" => ["DEPRECATION WARNING: Foo"])
+      deprecations = read_deprecations("test_exact_match")
+
+      assert_equal ["DEPRECATION WARNING: Foo"], deprecations
+    end
+
+    test "read falls back to normalized name match when exact key is missing" do
+      Configuration.deprecation_test_name_normalize = proc { |name| name.gsub(/_\[\d+\]/, "") }
+
+      write_deprecation_file("test_something" => ["DEPRECATION WARNING: Bar"])
+      deprecations = read_deprecations("test_something_[2]")
+
+      assert_equal ["DEPRECATION WARNING: Bar"], deprecations
+    end
+
+    test "read falls back to iterating normalized keys when neither exact nor direct normalized match" do
+      Configuration.deprecation_test_name_normalize = proc { |name| name.sub(/_tagged_.*$/, "") }
+
+      write_deprecation_file("test_example_tagged_v1" => ["DEPRECATION WARNING: Baz"])
+      deprecations = read_deprecations("test_example_tagged_v2")
+
+      assert_equal ["DEPRECATION WARNING: Baz"], deprecations
+    end
+
+    test "read returns empty array when no match found even with normalization" do
+      write_deprecation_file("test_unrelated" => ["DEPRECATION WARNING: Qux"])
+      deprecations = read_deprecations("test_completely_different")
+
+      assert_equal [], deprecations
+    end
+
+    test "write removes stale keys that normalize to the same name" do
+      Configuration.deprecation_test_name_normalize = proc { |name| name.gsub(/_\[\d+\]/, "") }
+
+      deprecation_file = write_deprecation_file(
+        "test_foo_[1]" => ["DEPRECATION WARNING: Old"],
+        "test_bar" => ["DEPRECATION WARNING: Other"],
+      )
+
+      deprecations_to_record = { "test_foo_[2]" => ["DEPRECATION WARNING: New"] }
+      Helper.write(deprecation_file, deprecations_to_record)
+
+      result = YAML.load_file(deprecation_file)
+
+      refute result.key?("test_foo_[1]")
+      assert_equal ["DEPRECATION WARNING: New"], result["test_foo_[2]"]
+      assert_equal ["DEPRECATION WARNING: Other"], result["test_bar"]
+    end
+
+    test "write does not remove the current key even if it normalizes to itself" do
+      Configuration.deprecation_test_name_normalize = proc { |name| name }
+
+      deprecation_file = write_deprecation_file("test_foo" => ["DEPRECATION WARNING: Existing"])
+
+      deprecations_to_record = { "test_foo" => ["DEPRECATION WARNING: Updated"] }
+      Helper.write(deprecation_file, deprecations_to_record)
+
+      result = YAML.load_file(deprecation_file)
+
+      assert_equal ["DEPRECATION WARNING: Updated"], result["test_foo"]
+    end
+
+    private
+
+    def write_deprecation_file(data)
+      path = Pathname(@deprecation_path).join("deprecation_toolkit/read_write_helper_test.yml")
+      path.dirname.mkpath
+      path.write(YAML.dump(data))
+      path
+    end
+
+    def read_deprecations(test_name)
+      fake_test = create_fake_test(test_name)
+      Helper.read(fake_test)
+    end
+
+    def create_fake_test(test_name)
+      klass = Class.new(ActiveSupport::TestCase)
+      klass.define_method(:class_name) { "DeprecationToolkit::ReadWriteHelperTest" }
+
+      def klass.name
+        "DeprecationToolkit::ReadWriteHelperTest"
+      end
+      klass.new(test_name)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Test names can sometimes change but the deprecation itself hasn't. This causes `DeprecationIntroduced` or `DeprecationRemoved` errors that require re-recording even though nothing meaningful changed. At scale (large test suites, bulk tag refactors), this creates unnecessary churn.

### Solution

Introduce a configurable `deprecation_test_name_normalize` proc that allows fuzzy matching between the current test name and the stored YAML key.

#### Read path

1. **Fast path** — exact key match (no overhead, same as today)
2. **Normalized fallback** — normalize both the current test name and stored keys, return the first match
3. **No match** — return `[]`

This means adding or removing tags won't break existing deprecation records.

#### Write path (during `--record-deprecations`)

- Store under the **actual** current test name (not normalized)
- Remove any stale key in the same file that normalizes to the same value, so old entries don't accumulate

## Open question: migrating stale keys

The normalized fallback works, but it's slower than an exact match. If deprecations haven't changed, nothing triggers a write, so stale keys persist and every read hits the slow path.

Requiring `--record-deprecations` to update keys doesn't reduce verbosity — it's the same amount of work as today, just for a different reason. The better end state may be to store under the normalized name directly, making the fast path the only path. The exact name is useful for debugging but isn't load-bearing if normalization is configured.

For now the fallback is acceptable. A future iteration could introduce a task to bulk-migrate keys, or shift to normalized storage by default when the config is set.
