### PR TITLE
Update to support minitest 6 plugin loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
           - gemfiles/activesupport_8.0.gemfile
           - gemfiles/activesupport_edge.gemfile
         ruby: ["3.2", "3.3", "3.4"]
+        exclude:
+          - ruby: "3.2"
+            gemfile: gemfiles/activesupport_edge.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/lib/deprecation_toolkit/minitest_hook.rb
+++ b/lib/deprecation_toolkit/minitest_hook.rb
@@ -2,6 +2,10 @@
 
 require "minitest"
 
+if Minitest.respond_to?(:load) && !Minitest.extensions.include?("deprecation_toolkit")
+  Minitest.load(:deprecation_toolkit)
+end
+
 module DeprecationToolkit
   module Minitest
     def trigger_deprecation_toolkit_behavior


### PR DESCRIPTION
December 2025 minitest released a new version that meant plugins weren't automatically discovered. This is causing issues in CI since it will automatically pull 6+ and we aren't manually loading when in this mode. 

This adds a quick check and performs manual loading if necessary. Backwards compatible when minitest <6 is used. 

Not explicitly bumping the Gemfile.lock so we can maintain full compatibility. 

Depends on https://github.com/Shopify/deprecation_toolkit/pull/161