### PR TITLE
Drop 3.2 active support check as it now required 3.3+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
           - gemfiles/activesupport_8.0.gemfile
           - gemfiles/activesupport_edge.gemfile
         ruby: ["3.2", "3.3", "3.4"]
+        exclude:
+          - ruby: "3.2"
+            gemfile: gemfiles/activesupport_edge.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:


### PR DESCRIPTION
The 3.2 check for active support is failing because active support now requires 3.3+. The alternative is dropping 3.2 support entirely. 

Depends on https://github.com/Shopify/deprecation_toolkit/pull/160 and I'll roll this change into that PR when shipping since they both fix CI in different ways 🤪 